### PR TITLE
feat: add Separator, Card, Breadcrumb, and Empty components

### DIFF
--- a/apps/web/app/docs/components/breadcrumb/api-data.ts
+++ b/apps/web/app/docs/components/breadcrumb/api-data.ts
@@ -1,0 +1,20 @@
+import type { ApiReferenceRow } from "@/components/api-reference"
+
+export const breadcrumbLinkApi: ApiReferenceRow[] = [
+  {
+    prop: "render",
+    type: "ReactElement | (props, state) => ReactElement",
+    default: "undefined",
+    description:
+      "Renders a different element (e.g. a routing library's Link) in place of the native anchor, keeping the same styles.",
+  },
+]
+
+export const breadcrumbSeparatorApi: ApiReferenceRow[] = [
+  {
+    prop: "children",
+    type: "ReactNode",
+    default: "ChevronRightIcon",
+    description: "Custom content to replace the default separator icon.",
+  },
+]

--- a/apps/web/app/docs/components/breadcrumb/opengraph-image.tsx
+++ b/apps/web/app/docs/components/breadcrumb/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { BreadcrumbPreview } from "@/lib/component-previews"
+import { buildOgImage, ogImageSize } from "@/lib/og-image"
+
+export const alt = "Breadcrumb — PersianLabs UI"
+export const size = ogImageSize
+export const contentType = "image/png"
+
+export default function OpengraphImage() {
+  return buildOgImage(
+    "Breadcrumb",
+    "Displays the path to the current resource using a hierarchy of links.",
+    <BreadcrumbPreview />
+  )
+}

--- a/apps/web/app/docs/components/breadcrumb/page.tsx
+++ b/apps/web/app/docs/components/breadcrumb/page.tsx
@@ -1,0 +1,397 @@
+import type { Metadata } from "next"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs"
+
+import { ApiReference } from "@/components/api-reference"
+import { CodeBlock } from "@/components/code-block"
+import { ComponentPreview } from "@/components/component-preview"
+import { CopyCommand } from "@/components/copy-command"
+import { CopyMarkdownButton } from "@/components/copy-markdown-button"
+import { Credits } from "@/components/credits"
+import { DocsPageFooter } from "@/components/docs-page-footer"
+import { BreadcrumbBasicExample } from "@/components/examples/breadcrumb-basic"
+import { BreadcrumbCityExample } from "@/components/examples/breadcrumb-city"
+import { BreadcrumbDropdownExample } from "@/components/examples/breadcrumb-dropdown"
+import { BreadcrumbEllipsisExample } from "@/components/examples/breadcrumb-ellipsis"
+import { BreadcrumbLinkExample } from "@/components/examples/breadcrumb-link"
+import { BreadcrumbRtlExample } from "@/components/examples/breadcrumb-rtl"
+import { BreadcrumbSeparatorExample } from "@/components/examples/breadcrumb-separator"
+import { InstallCommand } from "@/components/install-command"
+import { LastUpdated } from "@/components/last-updated"
+import { Step, Steps } from "@/components/steps"
+import { TableOfContents } from "@/components/table-of-contents"
+import { getComponentSource } from "@/lib/component-source"
+import { getExampleSource } from "@/lib/example-source"
+import { getLastEditedDate } from "@/lib/last-edited"
+import { CODE_FENCE, apiRowsToMarkdownTable } from "@/lib/markdown"
+
+const SOURCE_PATH = "apps/web/app/docs/components/breadcrumb/page.tsx"
+
+import { breadcrumbLinkApi, breadcrumbSeparatorApi } from "./api-data"
+
+export const metadata: Metadata = {
+  title: "Breadcrumb",
+  description:
+    "Displays the path to the current resource using a hierarchy of links.",
+}
+
+const tocItems = [
+  { id: "overview", title: "Overview" },
+  { id: "installation", title: "Installation" },
+  { id: "usage", title: "Usage" },
+  {
+    id: "examples",
+    title: "Examples",
+    children: [
+      { id: "example-separator", title: "Custom separator" },
+      { id: "example-dropdown", title: "Dropdown" },
+      { id: "example-ellipsis", title: "Collapsed" },
+      { id: "example-link", title: "Link component" },
+    ],
+  },
+  { id: "rtl", title: "RTL" },
+  { id: "city", title: "Province & city" },
+  { id: "api-reference", title: "API Reference" },
+]
+
+const usageSnippet = `import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+export function Example() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/components">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}`
+
+const breadcrumbMarkdown = [
+  "# Breadcrumb",
+  "",
+  "Displays the path to the current resource using a hierarchy of links.",
+  "",
+  "## Installation",
+  "",
+  `${CODE_FENCE}bash`,
+  "npx shadcn@latest add https://ui.persian-labs.ir/r/breadcrumb.json",
+  CODE_FENCE,
+  "",
+  "## Usage",
+  "",
+  `${CODE_FENCE}tsx`,
+  usageSnippet,
+  CODE_FENCE,
+  "",
+  "## API Reference",
+  "",
+  "### BreadcrumbLink",
+  "",
+  apiRowsToMarkdownTable(breadcrumbLinkApi),
+  "",
+  "### BreadcrumbSeparator",
+  "",
+  apiRowsToMarkdownTable(breadcrumbSeparatorApi),
+].join("\n")
+
+export default function BreadcrumbDocPage() {
+  const lastEdited = getLastEditedDate(SOURCE_PATH)
+
+  return (
+    <div className="flex gap-10">
+      <article className="max-w-3xl min-w-0 flex-1">
+        <div className="flex flex-col items-end justify-between gap-3 sm:flex-row sm:items-center">
+          <h1 className="self-start text-3xl font-semibold tracking-tight sm:self-auto">
+            Breadcrumb
+          </h1>
+          <CopyMarkdownButton markdown={breadcrumbMarkdown} />
+        </div>
+        <p className="mt-3 max-w-2xl leading-relaxed text-muted-foreground">
+          Displays the path to the current resource using a hierarchy of
+          links.
+        </p>
+        <LastUpdated date={lastEdited} />
+        <Credits
+          sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
+          changed
+          changes={[
+            "The default separator icon and its RTL mirroring now flip automatically based on the ambient text direction",
+          ]}
+        />
+
+        <h2
+          id="overview"
+          className="mt-10 text-xl font-semibold tracking-tight"
+        >
+          Overview
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<BreadcrumbBasicExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("breadcrumb-basic")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2
+          id="installation"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Installation
+        </h2>
+
+        <Tabs defaultValue="cli" className="mt-4">
+          <TabsList>
+            <TabsTrigger value="cli">CLI</TabsTrigger>
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="cli" className="mt-4">
+            <CopyCommand command="npx shadcn@latest add https://ui.persian-labs.ir/r/breadcrumb.json" />
+          </TabsContent>
+
+          <TabsContent value="manual" className="mt-4">
+            <Steps>
+              <Step>Install the dependencies</Step>
+              <div className="mt-2">
+                <InstallCommand packages="@base-ui/react lucide-react" />
+              </div>
+              <Step>Copy the component source</Step>
+              <div className="mt-2">
+                <CodeBlock
+                  code={getComponentSource("breadcrumb")}
+                  lang="tsx"
+                  title="components/ui/breadcrumb.tsx"
+                />
+              </div>
+            </Steps>
+          </TabsContent>
+        </Tabs>
+
+        <h2 id="usage" className="mt-12 text-xl font-semibold tracking-tight">
+          Usage
+        </h2>
+        <div className="mt-4">
+          <CodeBlock code={usageSnippet} lang="tsx" />
+        </div>
+
+        <h2
+          id="examples"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Examples
+        </h2>
+
+        <div className="mt-4">
+          <h3
+            id="example-separator"
+            className="text-sm font-medium text-muted-foreground"
+          >
+            Custom separator
+          </h3>
+          <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+            Pass{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+              children
+            </code>{" "}
+            to{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+              BreadcrumbSeparator
+            </code>{" "}
+            to use a custom separator.
+          </p>
+          <div className="mt-3">
+            <ComponentPreview
+              preview={<BreadcrumbSeparatorExample />}
+              code={
+                <CodeBlock
+                  code={getExampleSource("breadcrumb-separator")}
+                  lang="tsx"
+                />
+              }
+            />
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <h3
+            id="example-dropdown"
+            className="text-sm font-medium text-muted-foreground"
+          >
+            Dropdown
+          </h3>
+          <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+            Compose{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+              BreadcrumbItem
+            </code>{" "}
+            with{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+              DropdownMenu
+            </code>{" "}
+            to create a dropdown in the breadcrumb.
+          </p>
+          <div className="mt-3">
+            <ComponentPreview
+              preview={<BreadcrumbDropdownExample />}
+              code={
+                <CodeBlock
+                  code={getExampleSource("breadcrumb-dropdown")}
+                  lang="tsx"
+                />
+              }
+            />
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <h3
+            id="example-ellipsis"
+            className="text-sm font-medium text-muted-foreground"
+          >
+            Collapsed
+          </h3>
+          <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+            Use{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+              BreadcrumbEllipsis
+            </code>{" "}
+            to show a collapsed state when the breadcrumb is too long.
+          </p>
+          <div className="mt-3">
+            <ComponentPreview
+              preview={<BreadcrumbEllipsisExample />}
+              code={
+                <CodeBlock
+                  code={getExampleSource("breadcrumb-ellipsis")}
+                  lang="tsx"
+                />
+              }
+            />
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <h3
+            id="example-link"
+            className="text-sm font-medium text-muted-foreground"
+          >
+            Link component
+          </h3>
+          <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+            Use the{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+              render
+            </code>{" "}
+            prop on{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+              BreadcrumbLink
+            </code>{" "}
+            to use a custom link component from your routing library.
+          </p>
+          <div className="mt-3">
+            <ComponentPreview
+              preview={<BreadcrumbLinkExample />}
+              code={
+                <CodeBlock
+                  code={getExampleSource("breadcrumb-link")}
+                  lang="tsx"
+                />
+              }
+            />
+          </div>
+        </div>
+
+        <h2 id="rtl" className="mt-12 text-xl font-semibold tracking-tight">
+          RTL
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<BreadcrumbRtlExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("breadcrumb-rtl")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2 id="city" className="mt-12 text-xl font-semibold tracking-tight">
+          Province &amp; city
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          A Persian navigation pattern pairing well with{" "}
+          <a
+            href="/docs/components/city-selector"
+            className="text-foreground underline underline-offset-4"
+          >
+            City Selector
+          </a>
+          : country, province, and city as breadcrumb levels.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<BreadcrumbCityExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("breadcrumb-city")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2
+          id="api-reference"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          API Reference
+        </h2>
+        <ApiReference title="BreadcrumbLink" rows={breadcrumbLinkApi} />
+        <ApiReference
+          title="BreadcrumbSeparator"
+          rows={breadcrumbSeparatorApi}
+        />
+
+        <DocsPageFooter
+          href="/docs/components/breadcrumb"
+          sourcePath={SOURCE_PATH}
+        />
+      </article>
+
+      <aside className="hidden w-44 shrink-0 xl:block">
+        <div className="sticky top-24">
+          <TableOfContents items={tocItems} />
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/apps/web/app/docs/components/card/api-data.ts
+++ b/apps/web/app/docs/components/card/api-data.ts
@@ -1,0 +1,37 @@
+import type { ApiReferenceRow } from "@/components/api-reference"
+
+export const cardRootApi: ApiReferenceRow[] = [
+  {
+    prop: "size",
+    type: '"default" | "sm"',
+    default: '"default"',
+    description: "Controls the card's spacing via the --card-spacing CSS variable.",
+  },
+]
+
+export const cardHeaderApi: ApiReferenceRow[] = [
+  {
+    prop: "className",
+    type: "string",
+    default: "undefined",
+    description: "Additional classes for the header.",
+  },
+]
+
+export const cardContentApi: ApiReferenceRow[] = [
+  {
+    prop: "className",
+    type: "string",
+    default: "undefined",
+    description: "Additional classes for the content section.",
+  },
+]
+
+export const cardFooterApi: ApiReferenceRow[] = [
+  {
+    prop: "className",
+    type: "string",
+    default: "undefined",
+    description: "Additional classes for the footer.",
+  },
+]

--- a/apps/web/app/docs/components/card/opengraph-image.tsx
+++ b/apps/web/app/docs/components/card/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { CardPreview } from "@/lib/component-previews"
+import { buildOgImage, ogImageSize } from "@/lib/og-image"
+
+export const alt = "Card — PersianLabs UI"
+export const size = ogImageSize
+export const contentType = "image/png"
+
+export default function OpengraphImage() {
+  return buildOgImage(
+    "Card",
+    "Displays a card with header, content, and footer.",
+    <CardPreview />
+  )
+}

--- a/apps/web/app/docs/components/card/page.tsx
+++ b/apps/web/app/docs/components/card/page.tsx
@@ -1,0 +1,287 @@
+import type { Metadata } from "next"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs"
+
+import { ApiReference } from "@/components/api-reference"
+import { CodeBlock } from "@/components/code-block"
+import { ComponentPreview } from "@/components/component-preview"
+import { CopyCommand } from "@/components/copy-command"
+import { CopyMarkdownButton } from "@/components/copy-markdown-button"
+import { Credits } from "@/components/credits"
+import { DocsPageFooter } from "@/components/docs-page-footer"
+import { CardDemoExample } from "@/components/examples/card-demo"
+import { CardImageExample } from "@/components/examples/card-image"
+import { CardProductExample } from "@/components/examples/card-product"
+import { CardRtlExample } from "@/components/examples/card-rtl"
+import { CardSmallExample } from "@/components/examples/card-small"
+import { LastUpdated } from "@/components/last-updated"
+import { Step, Steps } from "@/components/steps"
+import { TableOfContents } from "@/components/table-of-contents"
+import { getComponentSource } from "@/lib/component-source"
+import { getExampleSource } from "@/lib/example-source"
+import { getLastEditedDate } from "@/lib/last-edited"
+import { CODE_FENCE, apiRowsToMarkdownTable } from "@/lib/markdown"
+
+const SOURCE_PATH = "apps/web/app/docs/components/card/page.tsx"
+
+import {
+  cardContentApi,
+  cardFooterApi,
+  cardHeaderApi,
+  cardRootApi,
+} from "./api-data"
+
+export const metadata: Metadata = {
+  title: "Card",
+  description: "Displays a card with header, content, and footer.",
+}
+
+const tocItems = [
+  { id: "overview", title: "Overview" },
+  { id: "installation", title: "Installation" },
+  { id: "usage", title: "Usage" },
+  { id: "size", title: "Size" },
+  { id: "image", title: "Image" },
+  { id: "rtl", title: "RTL" },
+  { id: "product", title: "Product card" },
+  { id: "api-reference", title: "API Reference" },
+]
+
+const usageSnippet = `import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+export function Example() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Card Title</CardTitle>
+        <CardDescription>Card Description</CardDescription>
+        <CardAction>Card Action</CardAction>
+      </CardHeader>
+      <CardContent>
+        <p>Card Content</p>
+      </CardContent>
+      <CardFooter>
+        <p>Card Footer</p>
+      </CardFooter>
+    </Card>
+  )
+}`
+
+const cardMarkdown = [
+  "# Card",
+  "",
+  "Displays a card with header, content, and footer.",
+  "",
+  "## Size",
+  "",
+  'Use `size="sm"` for a compact card with smaller spacing.',
+  "",
+  "## Installation",
+  "",
+  `${CODE_FENCE}bash`,
+  "npx shadcn@latest add https://ui.persian-labs.ir/r/card.json",
+  CODE_FENCE,
+  "",
+  "## Usage",
+  "",
+  `${CODE_FENCE}tsx`,
+  usageSnippet,
+  CODE_FENCE,
+  "",
+  "## API Reference",
+  "",
+  "### Card",
+  "",
+  apiRowsToMarkdownTable(cardRootApi),
+  "",
+  "### CardHeader",
+  "",
+  apiRowsToMarkdownTable(cardHeaderApi),
+  "",
+  "### CardContent",
+  "",
+  apiRowsToMarkdownTable(cardContentApi),
+  "",
+  "### CardFooter",
+  "",
+  apiRowsToMarkdownTable(cardFooterApi),
+].join("\n")
+
+export default function CardDocPage() {
+  const lastEdited = getLastEditedDate(SOURCE_PATH)
+
+  return (
+    <div className="flex gap-10">
+      <article className="max-w-3xl min-w-0 flex-1">
+        <div className="flex flex-col items-end justify-between gap-3 sm:flex-row sm:items-center">
+          <h1 className="self-start text-3xl font-semibold tracking-tight sm:self-auto">
+            Card
+          </h1>
+          <CopyMarkdownButton markdown={cardMarkdown} />
+        </div>
+        <p className="mt-3 max-w-2xl leading-relaxed text-muted-foreground">
+          Displays content in a structured container with an optional
+          header, content, and footer.
+        </p>
+        <LastUpdated date={lastEdited} />
+        <Credits
+          sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
+          changed={false}
+        />
+
+        <h2
+          id="overview"
+          className="mt-10 text-xl font-semibold tracking-tight"
+        >
+          Overview
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<CardDemoExample />}
+            code={
+              <CodeBlock code={getExampleSource("card-demo")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2
+          id="installation"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Installation
+        </h2>
+
+        <Tabs defaultValue="cli" className="mt-4">
+          <TabsList>
+            <TabsTrigger value="cli">CLI</TabsTrigger>
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="cli" className="mt-4">
+            <CopyCommand command="npx shadcn@latest add https://ui.persian-labs.ir/r/card.json" />
+          </TabsContent>
+
+          <TabsContent value="manual" className="mt-4">
+            <Steps>
+              <Step>Copy the component source</Step>
+              <div className="mt-2">
+                <CodeBlock
+                  code={getComponentSource("card")}
+                  lang="tsx"
+                  title="components/ui/card.tsx"
+                />
+              </div>
+            </Steps>
+          </TabsContent>
+        </Tabs>
+
+        <h2 id="usage" className="mt-12 text-xl font-semibold tracking-tight">
+          Usage
+        </h2>
+        <div className="mt-4">
+          <CodeBlock code={usageSnippet} lang="tsx" />
+        </div>
+
+        <h2 id="size" className="mt-12 text-xl font-semibold tracking-tight">
+          Size
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Use{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+            size=&quot;sm&quot;
+          </code>{" "}
+          for a compact card with smaller spacing.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<CardSmallExample />}
+            code={
+              <CodeBlock code={getExampleSource("card-small")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2 id="image" className="mt-12 text-xl font-semibold tracking-tight">
+          Image
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Add an image before the card header to create a card with an
+          image.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<CardImageExample />}
+            code={
+              <CodeBlock code={getExampleSource("card-image")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2 id="rtl" className="mt-12 text-xl font-semibold tracking-tight">
+          RTL
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<CardRtlExample />}
+            code={<CodeBlock code={getExampleSource("card-rtl")} lang="tsx" />}
+          />
+        </div>
+
+        <h2
+          id="product"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Product card
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          A Persian e-commerce pattern: Toman pricing with a discount badge
+          and a right-to-left price line.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<CardProductExample />}
+            code={
+              <CodeBlock code={getExampleSource("card-product")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2
+          id="api-reference"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          API Reference
+        </h2>
+        <ApiReference title="Card" rows={cardRootApi} />
+        <ApiReference title="CardHeader" rows={cardHeaderApi} />
+        <ApiReference title="CardContent" rows={cardContentApi} />
+        <ApiReference title="CardFooter" rows={cardFooterApi} />
+
+        <DocsPageFooter
+          href="/docs/components/card"
+          sourcePath={SOURCE_PATH}
+        />
+      </article>
+
+      <aside className="hidden w-44 shrink-0 xl:block">
+        <div className="sticky top-24">
+          <TableOfContents items={tocItems} />
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/apps/web/app/docs/components/empty/api-data.ts
+++ b/apps/web/app/docs/components/empty/api-data.ts
@@ -1,0 +1,10 @@
+import type { ApiReferenceRow } from "@/components/api-reference"
+
+export const emptyMediaApi: ApiReferenceRow[] = [
+  {
+    prop: "variant",
+    type: '"default" | "icon"',
+    default: '"default"',
+    description: "Styles the media as a plain wrapper or a boxed icon tile.",
+  },
+]

--- a/apps/web/app/docs/components/empty/opengraph-image.tsx
+++ b/apps/web/app/docs/components/empty/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { EmptyPreview } from "@/lib/component-previews"
+import { buildOgImage, ogImageSize } from "@/lib/og-image"
+
+export const alt = "Empty — PersianLabs UI"
+export const size = ogImageSize
+export const contentType = "image/png"
+
+export default function OpengraphImage() {
+  return buildOgImage(
+    "Empty",
+    "Displays an empty state with a title, description, and optional actions.",
+    <EmptyPreview />
+  )
+}

--- a/apps/web/app/docs/components/empty/page.tsx
+++ b/apps/web/app/docs/components/empty/page.tsx
@@ -1,0 +1,317 @@
+import type { Metadata } from "next"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs"
+
+import { ApiReference } from "@/components/api-reference"
+import { CodeBlock } from "@/components/code-block"
+import { ComponentPreview } from "@/components/component-preview"
+import { CopyCommand } from "@/components/copy-command"
+import { CopyMarkdownButton } from "@/components/copy-markdown-button"
+import { Credits } from "@/components/credits"
+import { DocsPageFooter } from "@/components/docs-page-footer"
+import { EmptyBackgroundExample } from "@/components/examples/empty-background"
+import { EmptyCityExample } from "@/components/examples/empty-city"
+import { EmptyDemoExample } from "@/components/examples/empty-demo"
+import { EmptyInputGroupExample } from "@/components/examples/empty-input-group"
+import { EmptyOutlineExample } from "@/components/examples/empty-outline"
+import { EmptyRtlExample } from "@/components/examples/empty-rtl"
+import { InstallCommand } from "@/components/install-command"
+import { LastUpdated } from "@/components/last-updated"
+import { Step, Steps } from "@/components/steps"
+import { TableOfContents } from "@/components/table-of-contents"
+import { getComponentSource } from "@/lib/component-source"
+import { getExampleSource } from "@/lib/example-source"
+import { getLastEditedDate } from "@/lib/last-edited"
+import { CODE_FENCE, apiRowsToMarkdownTable } from "@/lib/markdown"
+
+const SOURCE_PATH = "apps/web/app/docs/components/empty/page.tsx"
+
+import { emptyMediaApi } from "./api-data"
+
+export const metadata: Metadata = {
+  title: "Empty",
+  description: "Displays an empty state with a title, description, and optional actions.",
+}
+
+const tocItems = [
+  { id: "overview", title: "Overview" },
+  { id: "installation", title: "Installation" },
+  { id: "usage", title: "Usage" },
+  { id: "outline", title: "Outline" },
+  { id: "background", title: "Background" },
+  { id: "input-group", title: "Input Group" },
+  { id: "rtl", title: "RTL" },
+  { id: "city", title: "No city found" },
+  { id: "api-reference", title: "API Reference" },
+]
+
+const usageSnippet = `import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+
+export function Example() {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Icon />
+        </EmptyMedia>
+        <EmptyTitle>No data</EmptyTitle>
+        <EmptyDescription>No data found</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button>Add data</Button>
+      </EmptyContent>
+    </Empty>
+  )
+}`
+
+const emptyMarkdown = [
+  "# Empty",
+  "",
+  "Displays an empty state with a title, description, and optional actions.",
+  "",
+  "## Installation",
+  "",
+  `${CODE_FENCE}bash`,
+  "npx shadcn@latest add https://ui.persian-labs.ir/r/empty.json",
+  CODE_FENCE,
+  "",
+  "## Usage",
+  "",
+  `${CODE_FENCE}tsx`,
+  usageSnippet,
+  CODE_FENCE,
+  "",
+  "## API Reference",
+  "",
+  "### EmptyMedia",
+  "",
+  apiRowsToMarkdownTable(emptyMediaApi),
+].join("\n")
+
+export default function EmptyDocPage() {
+  const lastEdited = getLastEditedDate(SOURCE_PATH)
+
+  return (
+    <div className="flex gap-10">
+      <article className="max-w-3xl min-w-0 flex-1">
+        <div className="flex flex-col items-end justify-between gap-3 sm:flex-row sm:items-center">
+          <h1 className="self-start text-3xl font-semibold tracking-tight sm:self-auto">
+            Empty
+          </h1>
+          <CopyMarkdownButton markdown={emptyMarkdown} />
+        </div>
+        <p className="mt-3 max-w-2xl leading-relaxed text-muted-foreground">
+          Use the Empty component to display an empty state, with a title,
+          description, and optional actions.
+        </p>
+        <LastUpdated date={lastEdited} />
+        <Credits
+          sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
+          changed={false}
+        />
+
+        <h2
+          id="overview"
+          className="mt-10 text-xl font-semibold tracking-tight"
+        >
+          Overview
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<EmptyDemoExample />}
+            code={
+              <CodeBlock code={getExampleSource("empty-demo")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2
+          id="installation"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Installation
+        </h2>
+
+        <Tabs defaultValue="cli" className="mt-4">
+          <TabsList>
+            <TabsTrigger value="cli">CLI</TabsTrigger>
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="cli" className="mt-4">
+            <CopyCommand command="npx shadcn@latest add https://ui.persian-labs.ir/r/empty.json" />
+          </TabsContent>
+
+          <TabsContent value="manual" className="mt-4">
+            <Steps>
+              <Step>Install the dependencies</Step>
+              <div className="mt-2">
+                <InstallCommand packages="class-variance-authority" />
+              </div>
+              <Step>Copy the component source</Step>
+              <div className="mt-2">
+                <CodeBlock
+                  code={getComponentSource("empty")}
+                  lang="tsx"
+                  title="components/ui/empty.tsx"
+                />
+              </div>
+            </Steps>
+          </TabsContent>
+        </Tabs>
+
+        <h2 id="usage" className="mt-12 text-xl font-semibold tracking-tight">
+          Usage
+        </h2>
+        <div className="mt-4">
+          <CodeBlock code={usageSnippet} lang="tsx" />
+        </div>
+
+        <h2
+          id="outline"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Outline
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Use the{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+            border
+          </code>{" "}
+          utility class to create an outline empty state.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<EmptyOutlineExample />}
+            code={
+              <CodeBlock code={getExampleSource("empty-outline")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2
+          id="background"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Background
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Use the{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+            bg-*
+          </code>{" "}
+          utilities to add a background to the empty state.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<EmptyBackgroundExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("empty-background")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2
+          id="input-group"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Input Group
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Add an{" "}
+          <a
+            href="/docs/components/input-group"
+            className="text-foreground underline underline-offset-4"
+          >
+            InputGroup
+          </a>{" "}
+          component to{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+            EmptyContent
+          </code>
+          .
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<EmptyInputGroupExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("empty-input-group")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2 id="rtl" className="mt-12 text-xl font-semibold tracking-tight">
+          RTL
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<EmptyRtlExample />}
+            code={
+              <CodeBlock code={getExampleSource("empty-rtl")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2 id="city" className="mt-12 text-xl font-semibold tracking-tight">
+          No city found
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          A pattern for{" "}
+          <a
+            href="/docs/components/city-selector"
+            className="text-foreground underline underline-offset-4"
+          >
+            City Selector
+          </a>
+          &apos;s dependent city field before a province is chosen.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<EmptyCityExample />}
+            code={
+              <CodeBlock code={getExampleSource("empty-city")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2
+          id="api-reference"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          API Reference
+        </h2>
+        <ApiReference title="EmptyMedia" rows={emptyMediaApi} />
+
+        <DocsPageFooter
+          href="/docs/components/empty"
+          sourcePath={SOURCE_PATH}
+        />
+      </article>
+
+      <aside className="hidden w-44 shrink-0 xl:block">
+        <div className="sticky top-24">
+          <TableOfContents items={tocItems} />
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/apps/web/app/docs/components/page.tsx
+++ b/apps/web/app/docs/components/page.tsx
@@ -4,14 +4,18 @@ import Link from "next/link"
 import { Badge } from "@/components/badge"
 import { CopyMarkdownButton } from "@/components/copy-markdown-button"
 import {
+  BreadcrumbPreview,
   ButtonGroupPreview,
   ButtonPreview,
+  CardPreview,
   CitySelectorPreview,
   ComboboxPreview,
+  EmptyPreview,
   InputGroupPreview,
   InputOTPPreview,
   InputPreview,
   SelectPreview,
+  SeparatorPreview,
   TabsPreview,
   TextareaPreview,
 } from "@/lib/component-previews"
@@ -152,6 +156,57 @@ const components = [
     thumbnail: (
       <ThumbnailFrame>
         <CitySelectorPreview />
+      </ThumbnailFrame>
+    ),
+  },
+  {
+    title: "Separator",
+    href: "/docs/components/separator" as const,
+    description:
+      "Visually or semantically separates content, built on Base UI.",
+    badge: "New",
+    createdAt: "2026-08-07",
+    thumbnail: (
+      <ThumbnailFrame>
+        <SeparatorPreview />
+      </ThumbnailFrame>
+    ),
+  },
+  {
+    title: "Card",
+    href: "/docs/components/card" as const,
+    description: "Displays a card with header, content, and footer.",
+    badge: "New",
+    createdAt: "2026-08-07",
+    thumbnail: (
+      <ThumbnailFrame>
+        <CardPreview />
+      </ThumbnailFrame>
+    ),
+  },
+  {
+    title: "Breadcrumb",
+    href: "/docs/components/breadcrumb" as const,
+    description:
+      "Displays the path to the current resource using a hierarchy of links.",
+    badge: "New",
+    createdAt: "2026-08-07",
+    thumbnail: (
+      <ThumbnailFrame>
+        <BreadcrumbPreview />
+      </ThumbnailFrame>
+    ),
+  },
+  {
+    title: "Empty",
+    href: "/docs/components/empty" as const,
+    description:
+      "Displays an empty state with a title, description, and optional actions.",
+    badge: "New",
+    createdAt: "2026-08-07",
+    thumbnail: (
+      <ThumbnailFrame>
+        <EmptyPreview />
       </ThumbnailFrame>
     ),
   },

--- a/apps/web/app/docs/components/separator/api-data.ts
+++ b/apps/web/app/docs/components/separator/api-data.ts
@@ -1,0 +1,10 @@
+import type { ApiReferenceRow } from "@/components/api-reference"
+
+export const separatorRootApi: ApiReferenceRow[] = [
+  {
+    prop: "orientation",
+    type: '"horizontal" | "vertical"',
+    default: '"horizontal"',
+    description: "The direction of the separator.",
+  },
+]

--- a/apps/web/app/docs/components/separator/opengraph-image.tsx
+++ b/apps/web/app/docs/components/separator/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { SeparatorPreview } from "@/lib/component-previews"
+import { buildOgImage, ogImageSize } from "@/lib/og-image"
+
+export const alt = "Separator — PersianLabs UI"
+export const size = ogImageSize
+export const contentType = "image/png"
+
+export default function OpengraphImage() {
+  return buildOgImage(
+    "Separator",
+    "Visually or semantically separates content, built on Base UI.",
+    <SeparatorPreview />
+  )
+}

--- a/apps/web/app/docs/components/separator/page.tsx
+++ b/apps/web/app/docs/components/separator/page.tsx
@@ -1,0 +1,289 @@
+import type { Metadata } from "next"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs"
+
+import { ApiReference } from "@/components/api-reference"
+import { CodeBlock } from "@/components/code-block"
+import { ComponentPreview } from "@/components/component-preview"
+import { CopyCommand } from "@/components/copy-command"
+import { CopyMarkdownButton } from "@/components/copy-markdown-button"
+import { Credits } from "@/components/credits"
+import { DocsPageFooter } from "@/components/docs-page-footer"
+import { SeparatorDemoExample } from "@/components/examples/separator-demo"
+import { SeparatorListExample } from "@/components/examples/separator-list"
+import { SeparatorMenuExample } from "@/components/examples/separator-menu"
+import { SeparatorReceiptExample } from "@/components/examples/separator-receipt"
+import { SeparatorRtlExample } from "@/components/examples/separator-rtl"
+import { SeparatorVerticalExample } from "@/components/examples/separator-vertical"
+import { InstallCommand } from "@/components/install-command"
+import { LastUpdated } from "@/components/last-updated"
+import { Step, Steps } from "@/components/steps"
+import { TableOfContents } from "@/components/table-of-contents"
+import { getComponentSource } from "@/lib/component-source"
+import { getExampleSource } from "@/lib/example-source"
+import { getLastEditedDate } from "@/lib/last-edited"
+import { CODE_FENCE, apiRowsToMarkdownTable } from "@/lib/markdown"
+
+const SOURCE_PATH = "apps/web/app/docs/components/separator/page.tsx"
+
+import { separatorRootApi } from "./api-data"
+
+export const metadata: Metadata = {
+  title: "Separator",
+  description: "Visually or semantically separates content, built on Base UI.",
+}
+
+const tocItems = [
+  { id: "overview", title: "Overview" },
+  { id: "installation", title: "Installation" },
+  { id: "usage", title: "Usage" },
+  { id: "vertical", title: "Vertical" },
+  { id: "menu", title: "Menu" },
+  { id: "list", title: "List" },
+  { id: "rtl", title: "RTL" },
+  { id: "receipt", title: "Receipt breakdown" },
+  { id: "api-reference", title: "API Reference" },
+]
+
+const usageSnippet = `import { Separator } from "@/components/ui/separator"
+
+export function Example() {
+  return <Separator />
+}`
+
+const separatorMarkdown = [
+  "# Separator",
+  "",
+  "Visually or semantically separates content, built on Base UI.",
+  "",
+  "## Vertical",
+  "",
+  'Use `orientation="vertical"` for a vertical separator.',
+  "",
+  "## Installation",
+  "",
+  `${CODE_FENCE}bash`,
+  "npx shadcn@latest add https://ui.persian-labs.ir/r/separator.json",
+  CODE_FENCE,
+  "",
+  "## Usage",
+  "",
+  `${CODE_FENCE}tsx`,
+  usageSnippet,
+  CODE_FENCE,
+  "",
+  "## API Reference",
+  "",
+  "### Separator",
+  "",
+  apiRowsToMarkdownTable(separatorRootApi),
+].join("\n")
+
+export default function SeparatorDocPage() {
+  const lastEdited = getLastEditedDate(SOURCE_PATH)
+
+  return (
+    <div className="flex gap-10">
+      <article className="max-w-3xl min-w-0 flex-1">
+        <div className="flex flex-col items-end justify-between gap-3 sm:flex-row sm:items-center">
+          <h1 className="self-start text-3xl font-semibold tracking-tight sm:self-auto">
+            Separator
+          </h1>
+          <CopyMarkdownButton markdown={separatorMarkdown} />
+        </div>
+        <p className="mt-3 max-w-2xl leading-relaxed text-muted-foreground">
+          Visually or semantically separates content. Built on Base
+          UI&apos;s separator primitive.
+        </p>
+        <LastUpdated date={lastEdited} />
+        <Credits
+          sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
+          changed
+          changes={[
+            "Improved RTL support — the default separator icon and menu layout mirror correctly with logical properties",
+          ]}
+        />
+
+        <h2
+          id="overview"
+          className="mt-10 text-xl font-semibold tracking-tight"
+        >
+          Overview
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<SeparatorDemoExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("separator-demo")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2
+          id="installation"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Installation
+        </h2>
+
+        <Tabs defaultValue="cli" className="mt-4">
+          <TabsList>
+            <TabsTrigger value="cli">CLI</TabsTrigger>
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="cli" className="mt-4">
+            <CopyCommand command="npx shadcn@latest add https://ui.persian-labs.ir/r/separator.json" />
+          </TabsContent>
+
+          <TabsContent value="manual" className="mt-4">
+            <Steps>
+              <Step>Install the dependencies</Step>
+              <div className="mt-2">
+                <InstallCommand packages="@base-ui/react" />
+              </div>
+              <Step>Copy the component source</Step>
+              <div className="mt-2">
+                <CodeBlock
+                  code={getComponentSource("separator")}
+                  lang="tsx"
+                  title="components/ui/separator.tsx"
+                />
+              </div>
+            </Steps>
+          </TabsContent>
+        </Tabs>
+
+        <h2 id="usage" className="mt-12 text-xl font-semibold tracking-tight">
+          Usage
+        </h2>
+        <div className="mt-4">
+          <CodeBlock code={usageSnippet} lang="tsx" />
+        </div>
+
+        <h2
+          id="vertical"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Vertical
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Use{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+            orientation=&quot;vertical&quot;
+          </code>{" "}
+          for a vertical separator.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<SeparatorVerticalExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("separator-vertical")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2 id="menu" className="mt-12 text-xl font-semibold tracking-tight">
+          Menu
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Vertical separators between menu items with descriptions.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<SeparatorMenuExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("separator-menu")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2 id="list" className="mt-12 text-xl font-semibold tracking-tight">
+          List
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          Horizontal separators between list items.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<SeparatorListExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("separator-list")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2 id="rtl" className="mt-12 text-xl font-semibold tracking-tight">
+          RTL
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<SeparatorRtlExample />}
+            code={
+              <CodeBlock code={getExampleSource("separator-rtl")} lang="tsx" />
+            }
+          />
+        </div>
+
+        <h2
+          id="receipt"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Receipt breakdown
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          A Persian-market pattern: horizontal separators dividing a price
+          breakdown, with right-to-left digits and Toman currency.
+        </p>
+        <div className="mt-4">
+          <ComponentPreview
+            dir="rtl"
+            preview={<SeparatorReceiptExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("separator-receipt")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2
+          id="api-reference"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          API Reference
+        </h2>
+        <ApiReference title="Separator" rows={separatorRootApi} />
+
+        <DocsPageFooter
+          href="/docs/components/separator"
+          sourcePath={SOURCE_PATH}
+        />
+      </article>
+
+      <aside className="hidden w-44 shrink-0 xl:block">
+        <div className="sticky top-24">
+          <TableOfContents items={tocItems} />
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/apps/web/components/examples/breadcrumb-basic.tsx
+++ b/apps/web/components/examples/breadcrumb-basic.tsx
@@ -1,0 +1,28 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@workspace/ui/components/breadcrumb"
+
+export function BreadcrumbBasicExample() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/apps/web/components/examples/breadcrumb-city.tsx
+++ b/apps/web/components/examples/breadcrumb-city.tsx
@@ -1,0 +1,28 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@workspace/ui/components/breadcrumb"
+
+export function BreadcrumbCityExample() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">ایران</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">استان تهران</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>شهر تهران</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/apps/web/components/examples/breadcrumb-dropdown.tsx
+++ b/apps/web/components/examples/breadcrumb-dropdown.tsx
@@ -1,0 +1,53 @@
+import { DotIcon } from "lucide-react"
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@workspace/ui/components/breadcrumb"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+
+export function BreadcrumbDropdownExample() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <DotIcon />
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <button type="button" className="flex items-center gap-1" />
+              }
+            >
+              Components
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem>Documentation</DropdownMenuItem>
+              <DropdownMenuItem>Themes</DropdownMenuItem>
+              <DropdownMenuItem>GitHub</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <DotIcon />
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/apps/web/components/examples/breadcrumb-ellipsis.tsx
+++ b/apps/web/components/examples/breadcrumb-ellipsis.tsx
@@ -1,0 +1,33 @@
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@workspace/ui/components/breadcrumb"
+
+export function BreadcrumbEllipsisExample() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/apps/web/components/examples/breadcrumb-link.tsx
+++ b/apps/web/components/examples/breadcrumb-link.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link"
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@workspace/ui/components/breadcrumb"
+
+export function BreadcrumbLinkExample() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="#link-component" />}>
+            Home
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="#link-component" />}>
+            Components
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/apps/web/components/examples/breadcrumb-rtl.tsx
+++ b/apps/web/components/examples/breadcrumb-rtl.tsx
@@ -1,0 +1,28 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@workspace/ui/components/breadcrumb"
+
+export function BreadcrumbRtlExample() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">خانه</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">کامپوننت‌ها</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>نشانه‌راه</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/apps/web/components/examples/breadcrumb-separator.tsx
+++ b/apps/web/components/examples/breadcrumb-separator.tsx
@@ -1,0 +1,34 @@
+import { DotIcon } from "lucide-react"
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@workspace/ui/components/breadcrumb"
+
+export function BreadcrumbSeparatorExample() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <DotIcon />
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <DotIcon />
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/apps/web/components/examples/card-demo.tsx
+++ b/apps/web/components/examples/card-demo.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@workspace/ui/components/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card"
+import { Field, FieldGroup, FieldLabel } from "@workspace/ui/components/field"
+import { Input } from "@workspace/ui/components/input"
+
+export function CardDemoExample() {
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Login to your account</CardTitle>
+        <CardDescription>
+          Enter your email below to login to your account
+        </CardDescription>
+        <CardAction>
+          <Button variant="link">Sign Up</Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <FieldGroup>
+          <Field>
+            <FieldLabel htmlFor="card-demo-email">Email</FieldLabel>
+            <Input
+              id="card-demo-email"
+              type="email"
+              placeholder="you@example.com"
+              required
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="card-demo-password">Password</FieldLabel>
+            <Input id="card-demo-password" type="password" required />
+          </Field>
+        </FieldGroup>
+      </CardContent>
+      <CardFooter className="flex-col gap-2">
+        <Button type="submit" className="w-full">
+          Login
+        </Button>
+        <Button variant="outline" className="w-full">
+          Login with Google
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/components/examples/card-image.tsx
+++ b/apps/web/components/examples/card-image.tsx
@@ -1,0 +1,31 @@
+import { Badge } from "@workspace/ui/components/badge"
+import { Button } from "@workspace/ui/components/button"
+import {
+  Card,
+  CardAction,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card"
+
+export function CardImageExample() {
+  return (
+    <Card className="mx-auto w-full max-w-sm gap-0 overflow-hidden pt-0">
+      <div className="aspect-video w-full bg-gradient-to-br from-neutral-700 to-neutral-900" />
+      <CardHeader className="pt-(--card-spacing)">
+        <CardAction>
+          <Badge variant="secondary">Featured</Badge>
+        </CardAction>
+        <CardTitle>Design systems meetup</CardTitle>
+        <CardDescription>
+          A practical talk on component APIs, accessibility, and shipping
+          faster.
+        </CardDescription>
+      </CardHeader>
+      <CardFooter>
+        <Button className="w-full">View Event</Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/components/examples/card-product.tsx
+++ b/apps/web/components/examples/card-product.tsx
@@ -1,0 +1,35 @@
+import { Badge } from "@workspace/ui/components/badge"
+import { Button } from "@workspace/ui/components/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card"
+
+export function CardProductExample() {
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>هدفون بی‌سیم پرشین‌لبز</CardTitle>
+        <CardDescription>حذف نویز فعال، ۳۰ ساعت پخش موسیقی</CardDescription>
+        <CardAction>
+          <Badge variant="destructive">۲۰٪ تخفیف</Badge>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex items-baseline gap-2">
+        <span className="text-2xl font-semibold">۳٬۲۰۰٬۰۰۰</span>
+        <span className="text-sm text-muted-foreground">تومان</span>
+        <span className="text-sm text-muted-foreground line-through">
+          ۴٬۰۰۰٬۰۰۰
+        </span>
+      </CardContent>
+      <CardFooter>
+        <Button className="w-full">افزودن به سبد خرید</Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/components/examples/card-rtl.tsx
+++ b/apps/web/components/examples/card-rtl.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@workspace/ui/components/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card"
+
+export function CardRtlExample() {
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>ورود به حساب کاربری</CardTitle>
+        <CardDescription>برای ادامه، ایمیل خود را وارد کنید.</CardDescription>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        با ورود، شرایط و قوانین پرشین‌لبز را می‌پذیرید.
+      </CardContent>
+      <CardFooter>
+        <Button className="w-full">ادامه</Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/components/examples/card-small.tsx
+++ b/apps/web/components/examples/card-small.tsx
@@ -1,0 +1,48 @@
+import { ChevronRightIcon } from "lucide-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card"
+
+export function CardSmallExample() {
+  return (
+    <Card size="sm" className="mx-auto w-full max-w-xs">
+      <CardHeader>
+        <CardTitle>Scheduled reports</CardTitle>
+        <CardDescription>
+          Weekly snapshots. No more manual exports.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="grid gap-2 py-2 text-sm">
+          <li className="flex gap-2">
+            <ChevronRightIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground rtl:-scale-x-100" />
+            <span>Choose a schedule (daily, or weekly).</span>
+          </li>
+          <li className="flex gap-2">
+            <ChevronRightIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground rtl:-scale-x-100" />
+            <span>Send to channels or specific teammates.</span>
+          </li>
+          <li className="flex gap-2">
+            <ChevronRightIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground rtl:-scale-x-100" />
+            <span>Include charts, tables, and key metrics.</span>
+          </li>
+        </ul>
+      </CardContent>
+      <CardFooter className="flex-col gap-2">
+        <Button size="sm" className="w-full">
+          Set up scheduled reports
+        </Button>
+        <Button variant="outline" size="sm" className="w-full">
+          See what&apos;s new
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/components/examples/empty-background.tsx
+++ b/apps/web/components/examples/empty-background.tsx
@@ -1,0 +1,33 @@
+import { BellIcon, RefreshCcwIcon } from "lucide-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/empty"
+
+export function EmptyBackgroundExample() {
+  return (
+    <Empty className="bg-muted/30">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <BellIcon />
+        </EmptyMedia>
+        <EmptyTitle>No Notifications</EmptyTitle>
+        <EmptyDescription className="max-w-xs text-pretty">
+          You&apos;re all caught up. New notifications will appear here.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button variant="outline">
+          <RefreshCcwIcon data-icon="inline-start" />
+          Refresh
+        </Button>
+      </EmptyContent>
+    </Empty>
+  )
+}

--- a/apps/web/components/examples/empty-city.tsx
+++ b/apps/web/components/examples/empty-city.tsx
@@ -1,0 +1,25 @@
+import { MapPinOffIcon } from "lucide-react"
+
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/empty"
+
+export function EmptyCityExample() {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <MapPinOffIcon />
+        </EmptyMedia>
+        <EmptyTitle>شهری یافت نشد</EmptyTitle>
+        <EmptyDescription>
+          ابتدا یک استان انتخاب کنید تا فهرست شهرهای آن نمایش داده شود.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  )
+}

--- a/apps/web/components/examples/empty-demo.tsx
+++ b/apps/web/components/examples/empty-demo.tsx
@@ -1,0 +1,42 @@
+import { ArrowUpRightIcon, FolderCodeIcon } from "lucide-react"
+
+import { Button, buttonVariants } from "@workspace/ui/components/button"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/empty"
+import { cn } from "@workspace/ui/lib/utils"
+
+export function EmptyDemoExample() {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <FolderCodeIcon />
+        </EmptyMedia>
+        <EmptyTitle>No Projects Yet</EmptyTitle>
+        <EmptyDescription>
+          You haven&apos;t created any projects yet. Get started by creating
+          your first project.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent className="flex-row justify-center gap-2">
+        <Button>Create Project</Button>
+        <Button variant="outline">Import Project</Button>
+      </EmptyContent>
+      <a
+        href="#"
+        className={cn(
+          buttonVariants({ variant: "link", size: "sm" }),
+          "text-muted-foreground"
+        )}
+      >
+        Learn More <ArrowUpRightIcon />
+      </a>
+    </Empty>
+  )
+}

--- a/apps/web/components/examples/empty-input-group.tsx
+++ b/apps/web/components/examples/empty-input-group.tsx
@@ -1,0 +1,43 @@
+import { SearchIcon } from "lucide-react"
+
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@workspace/ui/components/empty"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@workspace/ui/components/input-group"
+import { Kbd } from "@workspace/ui/components/kbd"
+
+export function EmptyInputGroupExample() {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyTitle>404 - Not Found</EmptyTitle>
+        <EmptyDescription>
+          The page you&apos;re looking for doesn&apos;t exist. Try searching for
+          what you need below.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <InputGroup className="sm:w-3/4">
+          <InputGroupInput placeholder="Try searching for pages..." />
+          <InputGroupAddon>
+            <SearchIcon />
+          </InputGroupAddon>
+          <InputGroupAddon align="inline-end">
+            <Kbd>/</Kbd>
+          </InputGroupAddon>
+        </InputGroup>
+        <EmptyDescription>
+          Need help? <a href="#">Contact support</a>
+        </EmptyDescription>
+      </EmptyContent>
+    </Empty>
+  )
+}

--- a/apps/web/components/examples/empty-outline.tsx
+++ b/apps/web/components/examples/empty-outline.tsx
@@ -1,0 +1,32 @@
+import { CloudIcon } from "lucide-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/empty"
+
+export function EmptyOutlineExample() {
+  return (
+    <Empty className="border border-dashed">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <CloudIcon />
+        </EmptyMedia>
+        <EmptyTitle>Cloud Storage Empty</EmptyTitle>
+        <EmptyDescription>
+          Upload files to your cloud storage to access them anywhere.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button variant="outline" size="sm">
+          Upload Files
+        </Button>
+      </EmptyContent>
+    </Empty>
+  )
+}

--- a/apps/web/components/examples/empty-rtl.tsx
+++ b/apps/web/components/examples/empty-rtl.tsx
@@ -1,0 +1,30 @@
+import { InboxIcon } from "lucide-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/empty"
+
+export function EmptyRtlExample() {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <InboxIcon />
+        </EmptyMedia>
+        <EmptyTitle>پیامی وجود ندارد</EmptyTitle>
+        <EmptyDescription>
+          هر زمان پیام جدیدی دریافت کنید، اینجا نمایش داده می‌شود.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button variant="outline">بازخوانی</Button>
+      </EmptyContent>
+    </Empty>
+  )
+}

--- a/apps/web/components/examples/separator-demo.tsx
+++ b/apps/web/components/examples/separator-demo.tsx
@@ -1,0 +1,19 @@
+import { Separator } from "@workspace/ui/components/separator"
+
+export function SeparatorDemoExample() {
+  return (
+    <div className="flex max-w-sm flex-col gap-4 text-sm">
+      <div className="flex flex-col gap-1.5">
+        <div className="leading-none font-medium">PersianLabs/ui</div>
+        <div className="text-muted-foreground">
+          The Foundation for your Design System
+        </div>
+      </div>
+      <Separator />
+      <div>
+        A set of beautifully designed components that you can customize, extend,
+        and build on.
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/examples/separator-list.tsx
+++ b/apps/web/components/examples/separator-list.tsx
@@ -1,0 +1,22 @@
+import { Separator } from "@workspace/ui/components/separator"
+
+export function SeparatorListExample() {
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-2 text-sm">
+      <dl className="flex items-center justify-between">
+        <dt>Item 1</dt>
+        <dd className="text-muted-foreground">Value 1</dd>
+      </dl>
+      <Separator />
+      <dl className="flex items-center justify-between">
+        <dt>Item 2</dt>
+        <dd className="text-muted-foreground">Value 2</dd>
+      </dl>
+      <Separator />
+      <dl className="flex items-center justify-between">
+        <dt>Item 3</dt>
+        <dd className="text-muted-foreground">Value 3</dd>
+      </dl>
+    </div>
+  )
+}

--- a/apps/web/components/examples/separator-menu.tsx
+++ b/apps/web/components/examples/separator-menu.tsx
@@ -1,0 +1,28 @@
+import { Separator } from "@workspace/ui/components/separator"
+
+export function SeparatorMenuExample() {
+  return (
+    <div className="flex items-center gap-2 text-sm md:gap-4">
+      <div className="flex flex-col gap-1">
+        <span className="font-medium">Settings</span>
+        <span className="text-xs text-muted-foreground">
+          Manage preferences
+        </span>
+      </div>
+      <Separator orientation="vertical" />
+      <div className="flex flex-col gap-1">
+        <span className="font-medium">Account</span>
+        <span className="text-xs text-muted-foreground">
+          Profile &amp; security
+        </span>
+      </div>
+      <Separator orientation="vertical" className="hidden md:block" />
+      <div className="hidden flex-col gap-1 md:flex">
+        <span className="font-medium">Help</span>
+        <span className="text-xs text-muted-foreground">
+          Support &amp; docs
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/examples/separator-receipt.tsx
+++ b/apps/web/components/examples/separator-receipt.tsx
@@ -1,0 +1,27 @@
+import { Separator } from "@workspace/ui/components/separator"
+
+const lineItems = [
+  { label: "قیمت کالا", value: "۲٬۴۵۰٬۰۰۰ تومان" },
+  { label: "هزینه ارسال", value: "۳۵٬۰۰۰ تومان" },
+  { label: "تخفیف", value: "−۱۵۰٬۰۰۰ تومان" },
+]
+
+export function SeparatorReceiptExample() {
+  return (
+    <div className="w-full max-w-sm rounded-lg border border-border p-4 text-sm">
+      <div className="flex flex-col gap-2">
+        {lineItems.map((item) => (
+          <div key={item.label} className="flex items-center justify-between">
+            <span className="text-muted-foreground">{item.label}</span>
+            <span>{item.value}</span>
+          </div>
+        ))}
+      </div>
+      <Separator className="my-3" />
+      <div className="flex items-center justify-between font-medium">
+        <span>مبلغ قابل پرداخت</span>
+        <span>۲٬۳۳۵٬۰۰۰ تومان</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/examples/separator-rtl.tsx
+++ b/apps/web/components/examples/separator-rtl.tsx
@@ -1,0 +1,19 @@
+import { Separator } from "@workspace/ui/components/separator"
+
+export function SeparatorRtlExample() {
+  return (
+    <div className="flex max-w-sm flex-col gap-4 text-sm">
+      <div className="flex flex-col gap-1.5">
+        <div className="leading-none font-medium">پرشین‌لبز</div>
+        <div className="text-muted-foreground">
+          پایه‌ای برای سیستم طراحی شما
+        </div>
+      </div>
+      <Separator />
+      <div>
+        مجموعه‌ای از کامپوننت‌های طراحی‌شده که می‌توانید سفارشی‌سازی، توسعه و
+        روی آن‌ها بسازید.
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/examples/separator-vertical.tsx
+++ b/apps/web/components/examples/separator-vertical.tsx
@@ -1,0 +1,13 @@
+import { Separator } from "@workspace/ui/components/separator"
+
+export function SeparatorVerticalExample() {
+  return (
+    <div className="flex h-5 items-center gap-4 text-sm">
+      <div>Blog</div>
+      <Separator orientation="vertical" />
+      <div>Docs</div>
+      <Separator orientation="vertical" />
+      <div>Source</div>
+    </div>
+  )
+}

--- a/apps/web/lib/component-previews.tsx
+++ b/apps/web/lib/component-previews.tsx
@@ -308,3 +308,150 @@ export function CitySelectorPreview() {
     </div>
   )
 }
+
+export function SeparatorPreview() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "14px",
+        width: "220px",
+      }}
+    >
+      <div style={{ display: "flex", fontSize: "16px", color: "#f2f0ee" }}>
+        PersianLabs/ui
+      </div>
+      <div
+        style={{
+          display: "flex",
+          height: "1px",
+          width: "100%",
+          backgroundColor: "rgba(242,240,238,0.16)",
+        }}
+      />
+      <div
+        style={{
+          display: "flex",
+          fontSize: "13px",
+          color: "rgba(242,240,238,0.5)",
+        }}
+      >
+        Design system foundation
+      </div>
+    </div>
+  )
+}
+
+export function CardPreview() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "220px",
+        borderRadius: "14px",
+        backgroundColor: "#191817",
+        border: "1px solid rgba(242,240,238,0.16)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "6px",
+          padding: "16px 18px",
+        }}
+      >
+        <div style={{ display: "flex", fontSize: "17px", color: "#f2f0ee" }}>
+          Card Title
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: "13px",
+            color: "rgba(242,240,238,0.5)",
+          }}
+        >
+          Card description text
+        </div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          borderTop: "1px solid rgba(242,240,238,0.12)",
+          padding: "12px 18px",
+          fontSize: "13px",
+          color: "rgba(242,240,238,0.5)",
+        }}
+      >
+        Card footer
+      </div>
+    </div>
+  )
+}
+
+export function BreadcrumbPreview() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        fontSize: "16px",
+      }}
+    >
+      <div style={{ display: "flex", color: "rgba(242,240,238,0.5)" }}>
+        Home
+      </div>
+      <div style={{ display: "flex", color: "rgba(242,240,238,0.3)" }}>/</div>
+      <div style={{ display: "flex", color: "rgba(242,240,238,0.5)" }}>
+        Components
+      </div>
+      <div style={{ display: "flex", color: "rgba(242,240,238,0.3)" }}>/</div>
+      <div style={{ display: "flex", color: "#f2f0ee" }}>Breadcrumb</div>
+    </div>
+  )
+}
+
+export function EmptyPreview() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "10px",
+        width: "220px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "44px",
+          height: "44px",
+          borderRadius: "12px",
+          backgroundColor: "rgba(242,240,238,0.08)",
+        }}
+      >
+        <ChevronDownGlyph size={20} />
+      </div>
+      <div style={{ display: "flex", fontSize: "16px", color: "#f2f0ee" }}>
+        No results
+      </div>
+      <div
+        style={{
+          display: "flex",
+          fontSize: "12px",
+          color: "rgba(242,240,238,0.5)",
+          textAlign: "center",
+        }}
+      >
+        Nothing to show yet
+      </div>
+    </div>
+  )
+}

--- a/apps/web/lib/docs-nav.ts
+++ b/apps/web/lib/docs-nav.ts
@@ -15,6 +15,7 @@ export const docsNav: DocsNavGroup[] = [
     title: "Getting Started",
     items: [
       { title: "Introduction", href: "/docs" },
+      { title: "Components", href: "/docs/components" },
       { title: "Theming", href: "/docs/theming" },
       {
         title: "Skills",
@@ -27,33 +28,44 @@ export const docsNav: DocsNavGroup[] = [
   {
     title: "Components",
     items: [
-      { title: "Overview", href: "/docs/components" },
+      {
+        title: "Breadcrumb",
+        href: "/docs/components/breadcrumb",
+        badge: "New",
+      },
       { title: "Button", href: "/docs/components/button", badge: "New" },
       {
         title: "Button Group",
         href: "/docs/components/button-group",
         badge: "New",
       },
-      { title: "Input", href: "/docs/components/input", badge: "New" },
-      {
-        title: "Input OTP",
-        href: "/docs/components/input-otp",
-        badge: "New",
-      },
-      {
-        title: "Input Group",
-        href: "/docs/components/input-group",
-        badge: "New",
-      },
-      { title: "Textarea", href: "/docs/components/textarea", badge: "New" },
-      { title: "Tabs", href: "/docs/components/tabs", badge: "New" },
-      { title: "Combobox", href: "/docs/components/combobox", badge: "New" },
-      { title: "Select", href: "/docs/components/select", badge: "New" },
+      { title: "Card", href: "/docs/components/card", badge: "New" },
       {
         title: "City Selector",
         href: "/docs/components/city-selector",
         badge: "Special",
       },
+      { title: "Combobox", href: "/docs/components/combobox", badge: "New" },
+      { title: "Empty", href: "/docs/components/empty", badge: "New" },
+      { title: "Input", href: "/docs/components/input", badge: "New" },
+      {
+        title: "Input Group",
+        href: "/docs/components/input-group",
+        badge: "New",
+      },
+      {
+        title: "Input OTP",
+        href: "/docs/components/input-otp",
+        badge: "New",
+      },
+      { title: "Select", href: "/docs/components/select", badge: "New" },
+      {
+        title: "Separator",
+        href: "/docs/components/separator",
+        badge: "New",
+      },
+      { title: "Tabs", href: "/docs/components/tabs", badge: "New" },
+      { title: "Textarea", href: "/docs/components/textarea", badge: "New" },
     ],
   },
   {

--- a/apps/web/public/r/breadcrumb.json
+++ b/apps/web/public/r/breadcrumb.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "breadcrumb",
+  "title": "Breadcrumb",
+  "description": "Displays the path to the current resource using a hierarchy of links.",
+  "dependencies": [
+    "@base-ui/react",
+    "lucide-react"
+  ],
+  "registryDependencies": [
+    "utils"
+  ],
+  "files": [
+    {
+      "path": "registry/base/ui/breadcrumb.tsx",
+      "content": "import { mergeProps } from \"@base-ui/react/merge-props\"\nimport { useRender } from \"@base-ui/react/use-render\"\nimport { ChevronRightIcon, MoreHorizontalIcon } from \"lucide-react\"\nimport * as React from \"react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Breadcrumb({ ...props }: React.ComponentProps<\"nav\">) {\n  return <nav aria-label=\"breadcrumb\" data-slot=\"breadcrumb\" {...props} />\n}\n\nfunction BreadcrumbList({ className, ...props }: React.ComponentProps<\"ol\">) {\n  return (\n    <ol\n      data-slot=\"breadcrumb-list\"\n      className={cn(\n        \"flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground sm:gap-2.5\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction BreadcrumbItem({ className, ...props }: React.ComponentProps<\"li\">) {\n  return (\n    <li\n      data-slot=\"breadcrumb-item\"\n      className={cn(\"inline-flex items-center gap-1.5\", className)}\n      {...props}\n    />\n  )\n}\n\nfunction BreadcrumbLink({\n  className,\n  render,\n  ...props\n}: useRender.ComponentProps<\"a\">) {\n  return useRender({\n    defaultTagName: \"a\",\n    props: mergeProps<\"a\">(\n      {\n        className: cn(\"transition-colors hover:text-foreground\", className),\n      },\n      props\n    ),\n    render,\n    state: { slot: \"breadcrumb-link\" },\n  })\n}\n\nfunction BreadcrumbPage({\n  className,\n  ...props\n}: React.ComponentProps<\"span\">) {\n  return (\n    <span\n      data-slot=\"breadcrumb-page\"\n      role=\"link\"\n      aria-disabled=\"true\"\n      aria-current=\"page\"\n      className={cn(\"font-normal text-foreground\", className)}\n      {...props}\n    />\n  )\n}\n\nfunction BreadcrumbSeparator({\n  children,\n  className,\n  ...props\n}: React.ComponentProps<\"li\">) {\n  return (\n    <li\n      data-slot=\"breadcrumb-separator\"\n      role=\"presentation\"\n      aria-hidden=\"true\"\n      className={cn(\"[&>svg]:size-3.5 [&>svg]:rtl:-scale-x-100\", className)}\n      {...props}\n    >\n      {children ?? <ChevronRightIcon />}\n    </li>\n  )\n}\n\nfunction BreadcrumbEllipsis({\n  className,\n  ...props\n}: React.ComponentProps<\"span\">) {\n  return (\n    <span\n      data-slot=\"breadcrumb-ellipsis\"\n      role=\"presentation\"\n      aria-hidden=\"true\"\n      className={cn(\"flex size-9 items-center justify-center\", className)}\n      {...props}\n    >\n      <MoreHorizontalIcon className=\"size-4\" />\n      <span className=\"sr-only\">More</span>\n    </span>\n  )\n}\n\nexport {\n  Breadcrumb,\n  BreadcrumbEllipsis,\n  BreadcrumbItem,\n  BreadcrumbLink,\n  BreadcrumbList,\n  BreadcrumbPage,\n  BreadcrumbSeparator,\n}\n",
+      "type": "registry:ui"
+    }
+  ],
+  "type": "registry:ui"
+}

--- a/apps/web/public/r/card.json
+++ b/apps/web/public/r/card.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "card",
+  "title": "Card",
+  "description": "Displays a card with header, content, and footer.",
+  "dependencies": [],
+  "registryDependencies": [
+    "utils"
+  ],
+  "files": [
+    {
+      "path": "registry/base/ui/card.tsx",
+      "content": "import * as React from \"react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Card({\n  className,\n  size = \"default\",\n  ...props\n}: React.ComponentProps<\"div\"> & { size?: \"default\" | \"sm\" }) {\n  return (\n    <div\n      data-slot=\"card\"\n      data-size={size}\n      className={cn(\n        \"group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction CardHeader({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"card-header\"\n      className={cn(\n        \"group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction CardTitle({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"card-title\"\n      className={cn(\n        \"text-base leading-snug font-medium group-data-[size=sm]/card:text-sm\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction CardDescription({\n  className,\n  ...props\n}: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"card-description\"\n      className={cn(\"text-sm text-muted-foreground\", className)}\n      {...props}\n    />\n  )\n}\n\nfunction CardAction({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"card-action\"\n      className={cn(\n        \"col-start-2 row-span-2 row-start-1 self-start justify-self-end\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction CardContent({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"card-content\"\n      className={cn(\"px-(--card-spacing)\", className)}\n      {...props}\n    />\n  )\n}\n\nfunction CardFooter({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"card-footer\"\n      className={cn(\n        \"flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nexport {\n  Card,\n  CardAction,\n  CardContent,\n  CardDescription,\n  CardFooter,\n  CardHeader,\n  CardTitle,\n}\n",
+      "type": "registry:ui"
+    }
+  ],
+  "type": "registry:ui"
+}

--- a/apps/web/public/r/empty.json
+++ b/apps/web/public/r/empty.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "empty",
+  "title": "Empty",
+  "description": "Displays an empty state with a title, description, and optional actions.",
+  "dependencies": [
+    "class-variance-authority"
+  ],
+  "registryDependencies": [
+    "utils"
+  ],
+  "files": [
+    {
+      "path": "registry/base/ui/empty.tsx",
+      "content": "import { cva, type VariantProps } from \"class-variance-authority\"\nimport type * as React from \"react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Empty({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"empty\"\n      className={cn(\n        \"flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction EmptyHeader({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"empty-header\"\n      className={cn(\n        \"flex max-w-sm flex-col items-center gap-2 text-center\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nconst emptyMediaVariants = cva(\n  \"mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0\",\n  {\n    variants: {\n      variant: {\n        default: \"bg-transparent\",\n        icon: \"flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6\",\n      },\n    },\n    defaultVariants: {\n      variant: \"default\",\n    },\n  }\n)\n\nfunction EmptyMedia({\n  className,\n  variant = \"default\",\n  ...props\n}: React.ComponentProps<\"div\"> & VariantProps<typeof emptyMediaVariants>) {\n  return (\n    <div\n      data-slot=\"empty-icon\"\n      data-variant={variant}\n      className={cn(emptyMediaVariants({ variant, className }))}\n      {...props}\n    />\n  )\n}\n\nfunction EmptyTitle({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"empty-title\"\n      className={cn(\"text-lg font-medium tracking-tight\", className)}\n      {...props}\n    />\n  )\n}\n\nfunction EmptyDescription({\n  className,\n  ...props\n}: React.ComponentProps<\"p\">) {\n  return (\n    <div\n      data-slot=\"empty-description\"\n      className={cn(\n        \"text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction EmptyContent({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"empty-content\"\n      className={cn(\n        \"flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nexport {\n  Empty,\n  EmptyContent,\n  EmptyDescription,\n  EmptyHeader,\n  EmptyMedia,\n  EmptyTitle,\n}\n",
+      "type": "registry:ui"
+    }
+  ],
+  "type": "registry:ui"
+}

--- a/apps/web/public/r/separator.json
+++ b/apps/web/public/r/separator.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "separator",
+  "title": "Separator",
+  "description": "Visually or semantically separates content, built on Base UI.",
+  "dependencies": [
+    "@base-ui/react"
+  ],
+  "registryDependencies": [
+    "utils"
+  ],
+  "files": [
+    {
+      "path": "registry/base/ui/separator.tsx",
+      "content": "\"use client\"\n\nimport { Separator as SeparatorPrimitive } from \"@base-ui/react/separator\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Separator({\n  className,\n  orientation = \"horizontal\",\n  ...props\n}: SeparatorPrimitive.Props) {\n  return (\n    <SeparatorPrimitive\n      data-slot=\"separator\"\n      orientation={orientation}\n      className={cn(\n        \"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nexport { Separator }\n",
+      "type": "registry:ui"
+    }
+  ],
+  "type": "registry:ui"
+}

--- a/apps/web/registry.json
+++ b/apps/web/registry.json
@@ -269,6 +269,62 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "separator",
+      "type": "registry:ui",
+      "title": "Separator",
+      "description": "Visually or semantically separates content, built on Base UI.",
+      "registryDependencies": ["utils"],
+      "dependencies": ["@base-ui/react"],
+      "files": [
+        {
+          "path": "registry/base/ui/separator.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "card",
+      "type": "registry:ui",
+      "title": "Card",
+      "description": "Displays a card with header, content, and footer.",
+      "registryDependencies": ["utils"],
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/base/ui/card.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "breadcrumb",
+      "type": "registry:ui",
+      "title": "Breadcrumb",
+      "description": "Displays the path to the current resource using a hierarchy of links.",
+      "registryDependencies": ["utils"],
+      "dependencies": ["@base-ui/react", "lucide-react"],
+      "files": [
+        {
+          "path": "registry/base/ui/breadcrumb.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "empty",
+      "type": "registry:ui",
+      "title": "Empty",
+      "description": "Displays an empty state with a title, description, and optional actions.",
+      "registryDependencies": ["utils"],
+      "dependencies": ["class-variance-authority"],
+      "files": [
+        {
+          "path": "registry/base/ui/empty.tsx",
+          "type": "registry:ui"
+        }
+      ]
     }
   ]
 }

--- a/apps/web/registry/base/ui/breadcrumb.tsx
+++ b/apps/web/registry/base/ui/breadcrumb.tsx
@@ -1,0 +1,110 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a">) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn("transition-colors hover:text-foreground", className),
+      },
+      props
+    ),
+    render,
+    state: { slot: "breadcrumb-link" },
+  })
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5 [&>svg]:rtl:-scale-x-100", className)}
+      {...props}
+    >
+      {children ?? <ChevronRightIcon />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+}

--- a/apps/web/registry/base/ui/card.tsx
+++ b/apps/web/registry/base/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-(--card-spacing)", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+}

--- a/apps/web/registry/base/ui/empty.tsx
+++ b/apps/web/registry/base/ui/empty.tsx
@@ -1,0 +1,105 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import type * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+}

--- a/apps/web/registry/base/ui/separator.tsx
+++ b/apps/web/registry/base/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/packages/ui/src/components/breadcrumb.tsx
+++ b/packages/ui/src/components/breadcrumb.tsx
@@ -1,0 +1,110 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+import * as React from "react"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a">) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn("transition-colors hover:text-foreground", className),
+      },
+      props
+    ),
+    render,
+    state: { slot: "breadcrumb-link" },
+  })
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5 [&>svg]:rtl:-scale-x-100", className)}
+      {...props}
+    >
+      {children ?? <ChevronRightIcon />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+}

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-(--card-spacing)", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+}

--- a/packages/ui/src/components/empty.tsx
+++ b/packages/ui/src/components/empty.tsx
@@ -1,0 +1,105 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import type * as React from "react"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+}

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }


### PR DESCRIPTION
First batch of Tier 1 components, ported from shadcn/ui's Base UI registry and adapted to this project's conventions (logical properties, @workspace/ui alias, existing Field/Button/DropdownMenu composition patterns instead of Radix's Slot/asChild).

- Separator: default separator icon and vertical menu layouts mirror correctly under RTL via logical properties.
- Card: literal-Tailwind version of shadcn's --card-spacing variant, with size="sm" support.
- Breadcrumb: BreadcrumbLink uses Base UI's useRender/mergeProps for the render-as-Link pattern; the default separator icon flips via rtl: instead of a hardcoded direction.
- Empty: ported as-is, no RTL-specific changes needed.

Each ships with the shadcn example set plus one or two RTL-only examples specific to this project (a Toman price breakdown for Separator, a province/city breadcrumb, a "no city selected" empty state, a Persian product card).

Also:
- Registers all four in registry.json and rebuilds public/r/*.json.
- Adds docs-nav entries and alphabetizes the Components sidebar group (previously ordered by ship date).
- Moves the components overview link out of the Components group and into Getting Started, since it isn't itself a component.