### PR TITLE
fix: scroll active docs sidebar item into view on load and navigation

### DIFF
--- a/apps/web/components/docs-sidebar.tsx
+++ b/apps/web/components/docs-sidebar.tsx
@@ -45,8 +45,56 @@ function SidebarPreview({ item, group }: { item: DocsNavItem; group: string }) {
   )
 }
 
+/**
+ * Walks up from `el` to the nearest scrollable ancestor. The desktop
+ * sidebar sits inside a ScrollArea (Radix/Base UI sets overflow on its
+ * `[data-slot="scroll-area-viewport"]`), while the mobile nav's Dialog.Popup
+ * scrolls itself directly via a plain `overflow-y-auto` class -- walking up
+ * by computed style covers both without hardcoding either structure.
+ */
+function findScrollParent(el: HTMLElement): HTMLElement | null {
+  let node = el.parentElement
+  while (node) {
+    const style = getComputedStyle(node)
+    if (
+      /(auto|scroll)/.test(style.overflowY) &&
+      node.scrollHeight > node.clientHeight
+    ) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}
+
 export function DocsSidebar({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname()
+  const activeLinkRef = React.useRef<HTMLAnchorElement | null>(null)
+  const isFirstRender = React.useRef(true)
+
+  React.useEffect(() => {
+    const link = activeLinkRef.current
+    const wasFirstRender = isFirstRender.current
+    isFirstRender.current = false
+    if (!link) return
+
+    const viewport = findScrollParent(link)
+    if (!viewport) return
+
+    const linkRect = link.getBoundingClientRect()
+    const viewportRect = viewport.getBoundingClientRect()
+    const isVisible =
+      linkRect.top >= viewportRect.top && linkRect.bottom <= viewportRect.bottom
+    if (isVisible) return
+
+    // Direct page load: jump straight to centered, no animation. Client-side
+    // navigation to a page whose sidebar entry has scrolled out of view:
+    // ease it into view instead of snapping.
+    link.scrollIntoView({
+      block: "center",
+      behavior: wasFirstRender ? "instant" : "smooth",
+    })
+  }, [pathname])
 
   return (
     <TooltipProvider delay={0} closeDelay={0}>
@@ -82,6 +130,7 @@ export function DocsSidebar({ onNavigate }: { onNavigate?: () => void }) {
                         <TooltipTrigger
                           render={
                             <Link
+                              ref={active ? activeLinkRef : undefined}
                               href={item.href as Route}
                               onClick={onNavigate}
                               className={cn(
@@ -100,6 +149,7 @@ export function DocsSidebar({ onNavigate }: { onNavigate?: () => void }) {
                       </Tooltip>
                     ) : (
                       <Link
+                        ref={active ? activeLinkRef : undefined}
                         href={item.href as Route}
                         onClick={onNavigate}
                         className={cn(

--- a/apps/web/components/mobile-nav.tsx
+++ b/apps/web/components/mobile-nav.tsx
@@ -5,6 +5,7 @@ import { MenuIcon, XIcon } from "lucide-react"
 import * as React from "react"
 
 import { DocsSidebar } from "@/components/docs-sidebar"
+import { ScrollArea } from "@workspace/ui/components/scroll-area"
 
 export function MobileNav() {
   const [open, setOpen] = React.useState(false)
@@ -19,8 +20,8 @@ export function MobileNav() {
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <Dialog.Popup className="fixed inset-y-0 start-0 z-50 flex w-72 max-w-[85vw] flex-col overflow-y-auto border-e border-border bg-background p-6 shadow-lg transition-transform duration-200 data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full">
-          <div className="mb-6 flex items-center justify-between">
+        <Dialog.Popup className="fixed inset-y-0 start-0 z-50 flex w-72 max-w-[85vw] flex-col border-e border-border bg-background shadow-lg transition-transform duration-200 data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full">
+          <div className="mb-6 flex items-center justify-between p-6 pb-0">
             <Dialog.Title className="text-sm font-semibold">Menu</Dialog.Title>
             <Dialog.Close
               aria-label="Close menu"
@@ -29,7 +30,11 @@ export function MobileNav() {
               <XIcon className="size-4" />
             </Dialog.Close>
           </div>
-          <DocsSidebar onNavigate={() => setOpen(false)} />
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="px-6 pb-6">
+              <DocsSidebar onNavigate={() => setOpen(false)} />
+            </div>
+          </ScrollArea>
         </Dialog.Popup>
       </Dialog.Portal>
     </Dialog.Root>


### PR DESCRIPTION
On direct page load, instantly centers the active sidebar link if it's scrolled out of view. On client-side navigation, smooth-scrolls it into view only when the new active link isn't already visible, leaving scroll position untouched otherwise. Applies to both the desktop ScrollArea sidebar and the mobile nav drawer, which now also uses ScrollArea (with its scroll-fade edges) instead of plain overflow-y-auto.