### PR TITLE
fix: gallery preview card overflow and low-contrast pagination number

### DIFF
--- a/apps/web/app/docs/components/page.tsx
+++ b/apps/web/app/docs/components/page.tsx
@@ -142,7 +142,9 @@ const components = [
     createdAt: "2026-08-10",
     thumbnail: (
       <ThumbnailFrame>
-        <DatePickerPreview />
+        <div style={{ transform: "scale(0.6)" }}>
+          <DatePickerPreview />
+        </div>
       </ThumbnailFrame>
     ),
   },

--- a/apps/web/lib/component-previews.tsx
+++ b/apps/web/lib/component-previews.tsx
@@ -1676,9 +1676,7 @@ export function PaginationPreview() {
                   ? `1px solid ${preview.border}`
                   : "1px solid transparent",
                 backgroundColor: "transparent",
-                color: active
-                  ? preview.primaryForeground
-                  : preview.mutedForeground,
+                color: active ? preview.foreground : preview.mutedForeground,
                 fontSize: "12px",
                 fontWeight: active ? 600 : 500,
               }}


### PR DESCRIPTION
- Scale the Date Picker gallery thumbnail down so it fits inside the fixed-height ThumbnailFrame instead of getting clipped top and bottom
- Use the foreground color for the active pagination number instead of primary-foreground on a transparent background, which made it nearly invisible