### PR TITLE
feat: add Password Input component

### DIFF
--- a/apps/web/app/docs/components/page.tsx
+++ b/apps/web/app/docs/components/page.tsx
@@ -48,6 +48,7 @@ import {
   MessageScrollerPreview,
   NativeSelectPreview,
   PaginationPreview,
+  PasswordInputPreview,
   PopoverPreview,
   PriceInputPreview,
   ProgressPreview,
@@ -885,6 +886,19 @@ const components = [
     thumbnail: (
       <ThumbnailFrame>
         <PriceInputPreview />
+      </ThumbnailFrame>
+    ),
+  },
+  {
+    title: "Password Input",
+    href: "/docs/components/password-input" as const,
+    description:
+      "A password input with a show/hide toggle that always renders LTR, regardless of the surrounding document direction.",
+    badge: "New",
+    createdAt: "2026-08-16",
+    thumbnail: (
+      <ThumbnailFrame>
+        <PasswordInputPreview />
       </ThumbnailFrame>
     ),
   },

--- a/apps/web/app/docs/components/password-input/api-data.ts
+++ b/apps/web/app/docs/components/password-input/api-data.ts
@@ -1,0 +1,24 @@
+import type { ApiReferenceRow } from "@/components/api-reference"
+
+export const passwordInputApi: ApiReferenceRow[] = [
+  {
+    prop: "autoComplete",
+    type: "string",
+    default: "—",
+    description:
+      'Standard input autocomplete hint, e.g. "current-password" or "new-password".',
+  },
+  {
+    prop: "className",
+    type: "string",
+    default: "—",
+    description: "Applied to the underlying InputGroup.",
+  },
+  {
+    prop: "…props",
+    type: "React.ComponentProps<typeof InputGroupInput>",
+    default: "—",
+    description:
+      "All other props (value, defaultValue, onChange, placeholder, disabled, etc.) are forwarded to the input. type and dir are fixed and cannot be overridden.",
+  },
+]

--- a/apps/web/app/docs/components/password-input/opengraph-image.tsx
+++ b/apps/web/app/docs/components/password-input/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { PasswordInputPreview } from "@/lib/component-opengraph-previews"
+import { buildOgImage, ogImageSize } from "@/lib/og-image"
+
+export const alt = "Password Input — PersianLabs UI"
+export const size = ogImageSize
+export const contentType = "image/png"
+
+export default function OpengraphImage() {
+  return buildOgImage(
+    "Password Input",
+    "A show/hide password field that always renders LTR.",
+    <PasswordInputPreview />,
+    { previewScale: 1 }
+  )
+}

--- a/apps/web/app/docs/components/password-input/page.tsx
+++ b/apps/web/app/docs/components/password-input/page.tsx
@@ -1,0 +1,206 @@
+import type { Metadata } from "next"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs"
+
+import { ApiReference } from "@/components/api-reference"
+import { CodeBlock } from "@/components/code-block"
+import { ComponentPreview } from "@/components/component-preview"
+import { CopyCommand } from "@/components/copy-command"
+import { CopyMarkdownButton } from "@/components/copy-markdown-button"
+import { DocsPageFooter } from "@/components/docs-page-footer"
+import { PasswordInputDemoExample } from "@/components/examples/password-input-demo"
+import { PasswordInputRtlExample } from "@/components/examples/password-input-rtl"
+import { InstallCommand } from "@/components/install-command"
+import { LastUpdated } from "@/components/last-updated"
+import { Step, Steps } from "@/components/steps"
+import { TableOfContents } from "@/components/table-of-contents"
+import { getComponentSource } from "@/lib/component-source"
+import { getExampleSource } from "@/lib/example-source"
+import { getLastEditedDate } from "@/lib/last-edited"
+import { CODE_FENCE, apiRowsToMarkdownTable } from "@/lib/markdown"
+
+import { passwordInputApi } from "./api-data"
+
+const SOURCE_PATH = "apps/web/app/docs/components/password-input/page.tsx"
+
+export const metadata: Metadata = {
+  title: "Password Input",
+  description:
+    "A password input with a show/hide toggle that always renders LTR, regardless of the surrounding document direction.",
+}
+
+const tocItems = [
+  { id: "overview", title: "Overview" },
+  { id: "installation", title: "Installation" },
+  { id: "usage", title: "Usage" },
+  { id: "rtl", title: "RTL" },
+  { id: "api-reference", title: "API Reference" },
+]
+
+const usageSnippet = `import { PasswordInput } from "@/components/ui/password-input"
+
+export function Example() {
+  return <PasswordInput autoComplete="current-password" />
+}`
+
+export const passwordInputMarkdown = [
+  "# Password Input",
+  "",
+  "A password input with a show/hide toggle that always renders LTR, regardless of the surrounding document direction.",
+  "",
+  "## Installation",
+  "",
+  `${CODE_FENCE}bash`,
+  "npx shadcn@latest add https://ui.persian-labs.ir/r/password-input.json",
+  CODE_FENCE,
+  "",
+  "## Usage",
+  "",
+  `${CODE_FENCE}tsx`,
+  usageSnippet,
+  CODE_FENCE,
+  "",
+  "## API Reference",
+  "",
+  "### PasswordInput",
+  "",
+  apiRowsToMarkdownTable(passwordInputApi),
+].join("\n")
+
+export default function PasswordInputDocPage() {
+  const lastEdited = getLastEditedDate(SOURCE_PATH)
+
+  return (
+    <div className="flex gap-10">
+      <article className="max-w-3xl min-w-0 flex-1">
+        <div className="flex flex-col items-end justify-between gap-3 sm:flex-row sm:items-center">
+          <h1 className="self-start text-3xl font-semibold tracking-tight sm:self-auto">
+            Password Input
+          </h1>
+          <CopyMarkdownButton markdown={passwordInputMarkdown} />
+        </div>
+        <p className="mt-3 max-w-2xl leading-relaxed text-muted-foreground">
+          A single-field password input built on{" "}
+          <a
+            href="/docs/components/input-group"
+            className="text-foreground underline underline-offset-4"
+          >
+            Input Group
+          </a>
+          , with a show/hide toggle. Passwords are opaque strings, not
+          RTL-meaningful text, so the field forces{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+            dir=&quot;ltr&quot;
+          </code>{" "}
+          and keeps the toggle button on the same physical side, regardless of
+          the surrounding document direction.
+        </p>
+        <LastUpdated date={lastEdited} />
+
+        <h2
+          id="overview"
+          className="mt-10 text-xl font-semibold tracking-tight"
+        >
+          Overview
+        </h2>
+        <div className="mt-4">
+          <ComponentPreview
+            preview={<PasswordInputDemoExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("password-input-demo")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2
+          id="installation"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          Installation
+        </h2>
+
+        <Tabs defaultValue="cli" className="mt-4">
+          <TabsList>
+            <TabsTrigger value="cli">CLI</TabsTrigger>
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="cli" className="mt-4">
+            <CopyCommand command="npx shadcn@latest add https://ui.persian-labs.ir/r/password-input.json" />
+          </TabsContent>
+
+          <TabsContent value="manual" className="mt-4">
+            <Steps>
+              <Step>Install the component dependencies</Step>
+              <div className="mt-2">
+                <InstallCommand packages="lucide-react" />
+              </div>
+              <Step>Copy the component source</Step>
+              <div className="mt-2">
+                <CodeBlock
+                  code={getComponentSource("password-input")}
+                  lang="tsx"
+                  title="components/ui/password-input.tsx"
+                />
+              </div>
+            </Steps>
+          </TabsContent>
+        </Tabs>
+
+        <h2 id="usage" className="mt-12 text-xl font-semibold tracking-tight">
+          Usage
+        </h2>
+        <div className="mt-4">
+          <CodeBlock code={usageSnippet} lang="tsx" />
+        </div>
+
+        <h2 id="rtl" className="mt-12 text-xl font-semibold tracking-tight">
+          RTL
+        </h2>
+        <p className="mt-3 leading-relaxed text-muted-foreground">
+          The label and description follow the surrounding RTL layout, while the
+          password field and its toggle button stay LTR and keep the eye icon on
+          the same physical side.
+        </p>
+        <div className="mt-3">
+          <ComponentPreview
+            dir="rtl"
+            preview={<PasswordInputRtlExample />}
+            code={
+              <CodeBlock
+                code={getExampleSource("password-input-rtl")}
+                lang="tsx"
+              />
+            }
+          />
+        </div>
+
+        <h2
+          id="api-reference"
+          className="mt-12 text-xl font-semibold tracking-tight"
+        >
+          API Reference
+        </h2>
+        <ApiReference title="PasswordInput" rows={passwordInputApi} />
+
+        <DocsPageFooter
+          href="/docs/components/password-input"
+          sourcePath={SOURCE_PATH}
+        />
+      </article>
+
+      <aside className="hidden w-44 shrink-0 xl:block">
+        <div className="sticky top-24">
+          <TableOfContents items={tocItems} />
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/apps/web/components/examples/password-input-demo.tsx
+++ b/apps/web/components/examples/password-input-demo.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { PasswordInput } from "@workspace/ui/components/password-input"
+
+export function PasswordInputDemoExample() {
+  return (
+    <div className="w-full max-w-sm">
+      <PasswordInput placeholder="Password" autoComplete="current-password" />
+    </div>
+  )
+}

--- a/apps/web/components/examples/password-input-rtl.tsx
+++ b/apps/web/components/examples/password-input-rtl.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "@workspace/ui/components/field"
+import { PasswordInput } from "@workspace/ui/components/password-input"
+
+export function PasswordInputRtlExample() {
+  return (
+    <div className="w-full max-w-sm">
+      <Field>
+        <FieldLabel htmlFor="password-input-rtl">رمز عبور</FieldLabel>
+        <PasswordInput
+          id="password-input-rtl"
+          autoComplete="current-password"
+        />
+        <FieldDescription>
+          فیلد رمز عبور همیشه چپ‌به‌راست نمایش داده می‌شود، حتی در صفحات
+          راست‌به‌چپ.
+        </FieldDescription>
+      </Field>
+    </div>
+  )
+}

--- a/apps/web/lib/component-opengraph-previews.tsx
+++ b/apps/web/lib/component-opengraph-previews.tsx
@@ -3451,3 +3451,47 @@ export function BankInputPreview() {
     </div>
   )
 }
+
+export function PasswordInputPreview() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "14px",
+        width: "440px",
+        padding: "22px 28px",
+        borderRadius: "16px",
+        backgroundColor: "#191817",
+        border: "1px solid rgba(242,240,238,0.16)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          fontSize: "32px",
+          letterSpacing: "0.12em",
+          color: "#f2f0ee",
+        }}
+      >
+        ••••••••
+      </div>
+      <svg
+        aria-hidden="true"
+        width="28"
+        height="28"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="rgba(242,240,238,0.5)"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ display: "flex", flexShrink: 0 }}
+      >
+        <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+    </div>
+  )
+}

--- a/apps/web/lib/component-previews.tsx
+++ b/apps/web/lib/component-previews.tsx
@@ -2933,3 +2933,47 @@ export function BankInputPreview() {
     </div>
   )
 }
+
+export function PasswordInputPreview() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        width: "220px",
+        padding: "10px 14px",
+        borderRadius: "10px",
+        backgroundColor: preview.background,
+        border: `1px solid ${preview.border}`,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          fontSize: "18px",
+          letterSpacing: "0.1em",
+          color: preview.foreground,
+        }}
+      >
+        ••••••••
+      </div>
+      <svg
+        aria-hidden="true"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={preview.mutedForeground}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ display: "flex", flexShrink: 0 }}
+      >
+        <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+    </div>
+  )
+}

--- a/apps/web/lib/docs-nav.ts
+++ b/apps/web/lib/docs-nav.ts
@@ -106,6 +106,11 @@ export const docsNav: DocsNavGroup[] = [
       },
       { title: "Native Select", href: "/docs/components/native-select" },
       { title: "Pagination", href: "/docs/components/pagination" },
+      {
+        title: "Password Input",
+        href: "/docs/components/password-input",
+        badge: "New",
+      },
       { title: "Popover", href: "/docs/components/popover" },
       {
         title: "Price Input",

--- a/apps/web/public/r/password-input.json
+++ b/apps/web/public/r/password-input.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "password-input",
+  "title": "Password Input",
+  "description": "A password input with a show/hide toggle that always renders LTR, regardless of the surrounding document direction.",
+  "dependencies": [
+    "lucide-react"
+  ],
+  "registryDependencies": [
+    "utils",
+    "https://ui.persian-labs.ir/r/button.json",
+    "https://ui.persian-labs.ir/r/input-group.json"
+  ],
+  "files": [
+    {
+      "path": "registry/base/ui/password-input.tsx",
+      "content": "\"use client\"\n\nimport * as React from \"react\"\nimport { EyeIcon, EyeOffIcon } from \"lucide-react\"\n\nimport { Button } from \"@/components/ui/button\"\nimport {\n  InputGroup,\n  InputGroupAddon,\n  InputGroupInput,\n} from \"@/components/ui/input-group\"\nimport { cn } from \"@/lib/utils\"\n\nexport type PasswordInputProps = Omit<\n  React.ComponentProps<typeof InputGroupInput>,\n  \"type\" | \"dir\"\n>\n\nfunction PasswordInput({ className, ...props }: PasswordInputProps) {\n  const [showPassword, setShowPassword] = React.useState(false)\n\n  return (\n    // Passwords are opaque strings, not RTL-meaningful text, so the field\n    // (and the toggle button's position within it) always renders LTR\n    // regardless of the surrounding document direction — same rationale as\n    // CardNumberInput/ShabaInput in bank-input.tsx.\n    <InputGroup className={cn(\"h-auto\", className)} dir=\"ltr\">\n      <InputGroupInput\n        {...props}\n        dir=\"ltr\"\n        spellCheck={false}\n        type={showPassword ? \"text\" : \"password\"}\n      />\n      {/* `align=\"inline-end\"` resolves relative to the InputGroup's own\n          forced `dir=\"ltr\"`, so it always lands on the physical right,\n          independent of the host page's direction. */}\n      <InputGroupAddon align=\"inline-end\">\n        <Button\n          type=\"button\"\n          variant=\"ghost\"\n          size=\"icon-sm\"\n          aria-label={showPassword ? \"مخفی کردن رمز عبور\" : \"نمایش رمز عبور\"}\n          onClick={() => setShowPassword((v) => !v)}\n        >\n          {showPassword ? (\n            <EyeOffIcon className=\"size-4\" aria-hidden=\"true\" />\n          ) : (\n            <EyeIcon className=\"size-4\" aria-hidden=\"true\" />\n          )}\n        </Button>\n      </InputGroupAddon>\n    </InputGroup>\n  )\n}\n\nexport { PasswordInput }\n",
+      "type": "registry:ui"
+    }
+  ],
+  "type": "registry:ui"
+}

--- a/apps/web/public/r/registry.json
+++ b/apps/web/public/r/registry.json
@@ -959,6 +959,24 @@
       ]
     },
     {
+      "name": "password-input",
+      "type": "registry:ui",
+      "title": "Password Input",
+      "description": "A password input with a show/hide toggle that always renders LTR, regardless of the surrounding document direction.",
+      "registryDependencies": [
+        "utils",
+        "https://ui.persian-labs.ir/r/button.json",
+        "https://ui.persian-labs.ir/r/input-group.json"
+      ],
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "registry/base/ui/password-input.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "toast",
       "type": "registry:ui",
       "title": "Toast",

--- a/apps/web/registry.json
+++ b/apps/web/registry.json
@@ -959,6 +959,24 @@
       ]
     },
     {
+      "name": "password-input",
+      "type": "registry:ui",
+      "title": "Password Input",
+      "description": "A password input with a show/hide toggle that always renders LTR, regardless of the surrounding document direction.",
+      "registryDependencies": [
+        "utils",
+        "https://ui.persian-labs.ir/r/button.json",
+        "https://ui.persian-labs.ir/r/input-group.json"
+      ],
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "registry/base/ui/password-input.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "toast",
       "type": "registry:ui",
       "title": "Toast",

--- a/apps/web/registry/base/ui/password-input.tsx
+++ b/apps/web/registry/base/ui/password-input.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import * as React from "react"
+import { EyeIcon, EyeOffIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+import { cn } from "@/lib/utils"
+
+export type PasswordInputProps = Omit<
+  React.ComponentProps<typeof InputGroupInput>,
+  "type" | "dir"
+>
+
+function PasswordInput({ className, ...props }: PasswordInputProps) {
+  const [showPassword, setShowPassword] = React.useState(false)
+
+  return (
+    // Passwords are opaque strings, not RTL-meaningful text, so the field
+    // (and the toggle button's position within it) always renders LTR
+    // regardless of the surrounding document direction — same rationale as
+    // CardNumberInput/ShabaInput in bank-input.tsx.
+    <InputGroup className={cn("h-auto", className)} dir="ltr">
+      <InputGroupInput
+        {...props}
+        dir="ltr"
+        spellCheck={false}
+        type={showPassword ? "text" : "password"}
+      />
+      {/* `align="inline-end"` resolves relative to the InputGroup's own
+          forced `dir="ltr"`, so it always lands on the physical right,
+          independent of the host page's direction. */}
+      <InputGroupAddon align="inline-end">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={showPassword ? "مخفی کردن رمز عبور" : "نمایش رمز عبور"}
+          onClick={() => setShowPassword((v) => !v)}
+        >
+          {showPassword ? (
+            <EyeOffIcon className="size-4" aria-hidden="true" />
+          ) : (
+            <EyeIcon className="size-4" aria-hidden="true" />
+          )}
+        </Button>
+      </InputGroupAddon>
+    </InputGroup>
+  )
+}
+
+export { PasswordInput }

--- a/packages/ui/src/components/password-input.tsx
+++ b/packages/ui/src/components/password-input.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import * as React from "react"
+import { EyeIcon, EyeOffIcon } from "lucide-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@workspace/ui/components/input-group"
+import { cn } from "@workspace/ui/lib/utils"
+
+export type PasswordInputProps = Omit<
+  React.ComponentProps<typeof InputGroupInput>,
+  "type" | "dir"
+>
+
+function PasswordInput({ className, ...props }: PasswordInputProps) {
+  const [showPassword, setShowPassword] = React.useState(false)
+
+  return (
+    // Passwords are opaque strings, not RTL-meaningful text, so the field
+    // (and the toggle button's position within it) always renders LTR
+    // regardless of the surrounding document direction — same rationale as
+    // CardNumberInput/ShabaInput in bank-input.tsx.
+    <InputGroup className={cn("h-auto", className)} dir="ltr">
+      <InputGroupInput
+        {...props}
+        dir="ltr"
+        spellCheck={false}
+        type={showPassword ? "text" : "password"}
+      />
+      {/* `align="inline-end"` resolves relative to the InputGroup's own
+          forced `dir="ltr"`, so it always lands on the physical right,
+          independent of the host page's direction. */}
+      <InputGroupAddon align="inline-end">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={showPassword ? "مخفی کردن رمز عبور" : "نمایش رمز عبور"}
+          onClick={() => setShowPassword((v) => !v)}
+        >
+          {showPassword ? (
+            <EyeOffIcon className="size-4" aria-hidden="true" />
+          ) : (
+            <EyeIcon className="size-4" aria-hidden="true" />
+          )}
+        </Button>
+      </InputGroupAddon>
+    </InputGroup>
+  )
+}
+
+export { PasswordInput }


### PR DESCRIPTION
A text input with a show/hide toggle. Forces dir="ltr" since passwords are opaque strings, not RTL-meaningful text — matches CardNumberInput/ShabaInput's rationale in bank-input.tsx. Toggle button sits on the field's trailing (right) edge and uses type="button" so it never accidentally submits a wrapping form.