### PR TITLE
fix(calendar): keep Jalali month names in shamsi dropdown

### DIFF
--- a/apps/web/components/examples/__map__.ts
+++ b/apps/web/components/examples/__map__.ts
@@ -83,6 +83,7 @@ export const exampleLoaders: Record<string, () => Promise<React.ComponentType>> 
   "calendar-booked": () => import("@/components/examples/calendar-booked").then((m) => m.CalendarBookedExample),
   "calendar-calendar-type": () => import("@/components/examples/calendar-calendar-type").then((m) => m.CalendarCalendarTypeExample),
   "calendar-demo": () => import("@/components/examples/calendar-demo").then((m) => m.CalendarDemoExample),
+  "calendar-dropdown-miladi": () => import("@/components/examples/calendar-dropdown-miladi").then((m) => m.CalendarDropdownMiladiExample),
   "calendar-dropdown": () => import("@/components/examples/calendar-dropdown").then((m) => m.CalendarDropdownExample),
   "calendar-holidays": () => import("@/components/examples/calendar-holidays").then((m) => m.CalendarHolidaysExample),
   "calendar-presets": () => import("@/components/examples/calendar-presets").then((m) => m.CalendarPresetsExample),
@@ -533,6 +534,7 @@ export type ExampleMap = {
   "calendar-booked": React.ComponentType;
   "calendar-calendar-type": React.ComponentType;
   "calendar-demo": React.ComponentType;
+  "calendar-dropdown-miladi": React.ComponentType;
   "calendar-dropdown": React.ComponentType;
   "calendar-holidays": React.ComponentType;
   "calendar-presets": React.ComponentType;

--- a/apps/web/components/examples/calendar-dropdown-miladi.tsx
+++ b/apps/web/components/examples/calendar-dropdown-miladi.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+
+import { Calendar } from "@workspace/ui/components/calendar"
+
+export function CalendarDropdownMiladiExample() {
+  const [date, setDate] = React.useState<Date | undefined>(undefined)
+  const [today, setToday] = React.useState<Date | null>(null)
+
+  React.useEffect(() => {
+    const init = () => {
+      const now = new Date()
+      setToday(now)
+      setDate(now)
+    }
+    init()
+  }, [])
+
+  if (!today) return null
+
+  return (
+    <Calendar
+      mode="single"
+      calendarType="miladi"
+      selected={date}
+      onSelect={setDate}
+      defaultMonth={today}
+      captionLayout="dropdown"
+      className="rounded-lg border"
+    />
+  )
+}

--- a/apps/web/content/docs/components/calendar.mdx
+++ b/apps/web/content/docs/components/calendar.mdx
@@ -10,19 +10,19 @@ A date-grid calendar built on [react-day-picker](https://daypicker.dev), with a 
 <LastEdited path="apps/web/content/docs/components/calendar.mdx" />
 
 <Credits
-          sources={[
-            { label: "shadcn/ui", href: "https://ui.shadcn.com" },
-            {
-              label: "coss/ui",
-              href: "https://coss.com/ui/docs/components/calendar",
-            },
-          ]}
-          changed
-          changes={[
-            'Adds a calendarType prop ("shamsi" | "miladi") that switches between @daypicker/persian (faIR locale, RTL, Persian numerals) and react-day-picker (enUS locale, LTR, Latin numerals), defaulting to "shamsi"',
-            "Replaces pr-/pl- and rounded-l-/rounded-r- with pe-/ps- and rounded-e-/rounded-s- (logical properties) throughout",
-          ]}
-        />
+  sources={[
+    { label: "shadcn/ui", href: "https://ui.shadcn.com" },
+    {
+      label: "coss/ui",
+      href: "https://coss.com/ui/docs/components/calendar",
+    },
+  ]}
+  changed
+  changes={[
+    'Adds a calendarType prop ("shamsi" | "miladi") that switches between @daypicker/persian (faIR locale, RTL, Persian numerals) and react-day-picker (enUS locale, LTR, Latin numerals), defaulting to "shamsi"',
+    "Replaces pr-/pl- and rounded-l-/rounded-r- with pe-/ps- and rounded-e-/rounded-s- (logical properties) throughout",
+  ]}
+/>
 
 ## Overview
 
@@ -30,7 +30,12 @@ A date-grid calendar built on [react-day-picker](https://daypicker.dev), with a 
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/calendar" packages="react-day-picker @daypicker/persian date-fns" sourceName="calendar" sourceTitle="components/ui/calendar.tsx" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/calendar"
+  packages="react-day-picker @daypicker/persian date-fns"
+  sourceName="calendar"
+  sourceTitle="components/ui/calendar.tsx"
+/>
 
 ## Usage
 
@@ -53,40 +58,53 @@ export function Example() {
 
 ## Examples
 
-<ExampleSection id="calendar-type"
-  title="Calendar Type"
-  description="Set calendarType to switch between the Jalali (Shamsi, the default) and Gregorian (Miladi) calendars. Shamsi renders via @daypicker/persian with the faIR locale, RTL direction, and Persian numerals; Miladi renders via react-day-picker with the enUS locale, LTR direction, and Latin numerals."
-  name="calendar-calendar-type" />
+### Calendar Type
 
-<ExampleSection id="range"
-  title="Range Calendar"
-  description={"Use `mode=\"range\"` with a controlled `selected` value and `onSelect`. One responsive calendar handles both endpoints."}
-  name="calendar-range" />
+Set calendarType to switch between the Jalali (Shamsi, the default) and Gregorian (Miladi) calendars. Shamsi renders via @daypicker/persian with the faIR locale, RTL direction, and Persian numerals; Miladi renders via react-day-picker with the enUS locale, LTR direction, and Latin numerals.
 
-<ExampleSection id="dropdown"
-  title="Month and Year Selector"
-  description={"Use `captionLayout=\"dropdown\"`."}
-  name="calendar-dropdown" />
+<ComponentPreview name="calendar-calendar-type" />
 
-<ExampleSection id="presets"
-  title="Presets"
-  description="A calendar with a scrollable preset sidebar on desktop and a compact Drawer trigger above the month on smaller screens."
-  name="calendar-presets" />
+### Range Calendar
 
-<ExampleSection id="booked"
-  title="Booked Dates"
-  description="Combine `disabled` with a `booked` modifier to strike through unavailable dates."
-  name="calendar-booked" />
+Use `mode="range"` with a controlled `selected` value and `onSelect`. One responsive calendar handles both endpoints.
 
-<ExampleSection id="week-numbers"
-  title="Week Numbers"
-  description="Use `showWeekNumber` to display the ISO week number."
-  name="calendar-week-numbers" />
+<ComponentPreview name="calendar-range" />
 
-<ExampleSection id="holidays"
-  title="Holidays"
-  description="Pass `showHolidays` to highlight Iranian holidays (red text) for the visible month, using [persian-holidays](/docs/utilities/persian-holidays) internally. Hover a holiday to see its title and whether it's an official day off or just a commemorative occasion."
-  name="calendar-holidays" />
+### Month and Year Selector
+
+Use `captionLayout="dropdown"`. The dropdown labels come from each picker's own date library, so Shamsi shows Jalali month names (فروردین، اردیبهشت، …) and Miladi shows Gregorian ones.
+
+<ComponentPreview name="calendar-dropdown" />
+
+### Month and Year Selector (Miladi)
+
+Use `captionLayout="dropdown"` with `calendarType="miladi"` for Gregorian month/year labels.
+
+<ComponentPreview name="calendar-dropdown-miladi" />
+
+### Presets
+
+A calendar with a scrollable preset sidebar on desktop and a compact Drawer trigger above the month on smaller screens.
+
+<ComponentPreview name="calendar-presets" />
+
+### Booked Dates
+
+Combine `disabled` with a `booked` modifier to strike through unavailable dates.
+
+<ComponentPreview name="calendar-booked" />
+
+### Week Numbers
+
+Use `showWeekNumber` to display the ISO week number.
+
+<ComponentPreview name="calendar-week-numbers" />
+
+### Holidays
+
+Pass `showHolidays` to highlight Iranian holidays (red text) for the visible month, using [persian-holidays](/docs/utilities/persian-holidays) internally. Hover a holiday to see its title and whether it's an official day off or just a commemorative occasion.
+
+<ComponentPreview name="calendar-holidays" />
 
 ### RTL
 

--- a/apps/web/registry/base/ui/calendar.tsx
+++ b/apps/web/registry/base/ui/calendar.tsx
@@ -196,8 +196,14 @@ function Calendar({
     dir: resolvedDir,
     numerals: resolvedNumerals,
     formatters: {
-      formatMonthDropdown: (date: Date) =>
-        date.toLocaleString("default", { month: "short" }),
+      // Shortening the dropdown label via the underlying Date's Gregorian
+      // month only makes sense for miladi -- for shamsi that leaks English
+      // month names ("Aug") into the Jalali picker, so @daypicker/persian's
+      // own Jalali-aware default formatter (e.g. "مرداد") is kept instead.
+      ...(calendarType === "miladi" && {
+        formatMonthDropdown: (date: Date) =>
+          date.toLocaleString("default", { month: "short" }),
+      }),
       ...formatters,
     },
     classNames: {

--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -196,8 +196,14 @@ function Calendar({
     dir: resolvedDir,
     numerals: resolvedNumerals,
     formatters: {
-      formatMonthDropdown: (date: Date) =>
-        date.toLocaleString("default", { month: "short" }),
+      // Shortening the dropdown label via the underlying Date's Gregorian
+      // month only makes sense for miladi -- for shamsi that leaks English
+      // month names ("Aug") into the Jalali picker, so @daypicker/persian's
+      // own Jalali-aware default formatter (e.g. "مرداد") is kept instead.
+      ...(calendarType === "miladi" && {
+        formatMonthDropdown: (date: Date) =>
+          date.toLocaleString("default", { month: "short" }),
+      }),
       ...formatters,
     },
     classNames: {


### PR DESCRIPTION
## Summary

Fixes #52

The `captionLayout="dropdown"` month labels were hardcoded to the underlying Date's **Gregorian** month (`date.toLocaleString("default", { month: "short" })`), so the Shamsi calendar showed English month abbreviations (e.g. "Aug") while its year and grid were correctly Jalali.

- Apply the short-month override only for `calendarType="miladi"`; Shamsi now falls through to @daypicker/persian's own Jalali-aware default formatter (فروردین، اردیبهشت، …)
- Mirror the fix into the registry copy
- Convert calendar.mdx example subsections from `<ExampleSection>` (runtime h3, invisible to fumadocs TOC extraction) to real markdown headings, so all examples appear in the page TOC
- Add a new "Month and Year Selector (Miladi)" example covering the dropdown in Gregorian mode

## Verification

- `bun run lint`, `bun run typecheck` pass in packages/ui and apps/web; 98 unit tests pass
- `bun scripts/check-mdx-components.mts` passes
