### PR TITLE
fix(toc): drop font-weight toggle on active items to avoid layout shift

### DIFF
--- a/apps/web/components/table-of-contents.tsx
+++ b/apps/web/components/table-of-contents.tsx
@@ -343,7 +343,7 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
                     className={cn(
                       "relative block py-1 pl-4 transition-colors",
                       isActiveOrParentOfActive(item)
-                        ? "font-medium text-foreground"
+                        ? "text-foreground"
                         : "text-muted-foreground hover:text-foreground"
                     )}
                   >
@@ -365,7 +365,7 @@ export function TableOfContents({ items }: { items: TocItem[] }) {
                       className={cn(
                         "relative block py-1 pl-7 text-[13px] transition-colors",
                         activeIds.includes(child.id)
-                          ? "font-medium text-foreground"
+                          ? "text-foreground"
                           : "text-muted-foreground hover:text-foreground"
                       )}
                     >


### PR DESCRIPTION
## Summary

Active items in the docs "On this page" TOC toggled `font-medium`, so scrolling changed glyph widths, re-wrapped titles, and shifted row layout on every section change (also invalidating the connector-line measurements).

- Removed `font-medium` from the active states of both top-level and child items (apps/web/components/table-of-contents.tsx)
- Active state is still clearly communicated by `text-foreground` vs `text-muted-foreground` plus the animated primary connector line — no font-weight change, no shift

## Verification

- `bun run lint` passes in apps/web; prettier clean
