### PR TITLE
docs: surface example subsections in TOC across all pages

### DIFF
--- a/apps/web/content/docs/components/bank-input.mdx
+++ b/apps/web/content/docs/components/bank-input.mdx
@@ -17,7 +17,12 @@ Payment-ready Iranian card and Shaba fields. They normalize mixed paste formats,
 
 Install the inputs, their bank utility, input-group primitives, and the PersianLabs icon package in one step.
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/bank-input" packages="@persianlabs/icons" sourceName="bank-input" sourceTitle="components/ui/bank-input.tsx" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/bank-input"
+  packages="@persianlabs/icons"
+  sourceName="bank-input"
+  sourceTitle="components/ui/bank-input.tsx"
+/>
 
 ## Usage
 
@@ -31,27 +36,31 @@ export function Example() {
 
 ## Examples
 
-<ExampleSection id="shaba"
-  title="Shaba"
-  description="The IR prefix is presented as an input-group prefix. Pasting an entire IBAN, with or without separators, removes IR and normalizes the remaining 24 digits."
-  name="bank-input-shaba" />
-<ExampleSection id="zod"
-  title="Zod Validation"
-  description="Use the exported checksum validators in Zod refinements, while the inputs surface invalid complete values immediately."
-  name="bank-input-zod" />
-<ExampleSection id="separator"
-  title="Separator"
-  description="Card numbers use spaces by default (1234 1234 1234 1234). Pass separator to use any other display delimiter; the stored value always stays as 16 plain digits."
-  name="bank-input-separator" />
-<ExampleSection id="supported-banks"
-  title="Supported Banks"
-  description="هر ورودی یک شماره کارت معتبر نمونه دارد؛ لوگوی انتهایی نشان می‌دهد که تشخیص بانک برای همه بانک‌های پشتیبانی‌شده فعال است."
-  name="bank-input-supported-banks" />
-<ExampleSection id="rtl"
-  title="RTL"
-  description="Labels, descriptions, and bank names follow the surrounding RTL interface while the card and Shaba values remain intentionally LTR. Persian digits are normalized during input."
-  name="bank-input-rtl"
-  direction="rtl" />
+### Shaba [#shaba]
+
+The IR prefix is presented as an input-group prefix. Pasting an entire IBAN, with or without separators, removes IR and normalizes the remaining 24 digits.
+
+<ComponentPreview name="bank-input-shaba" />
+### Zod Validation [#zod]
+
+Use the exported checksum validators in Zod refinements, while the inputs surface invalid complete values immediately.
+
+<ComponentPreview name="bank-input-zod" />
+### Separator [#separator]
+
+Card numbers use spaces by default (1234 1234 1234 1234). Pass separator to use any other display delimiter; the stored value always stays as 16 plain digits.
+
+<ComponentPreview name="bank-input-separator" />
+### Supported Banks [#supported-banks]
+
+هر ورودی یک شماره کارت معتبر نمونه دارد؛ لوگوی انتهایی نشان می‌دهد که تشخیص بانک برای همه بانک‌های پشتیبانی‌شده فعال است.
+
+<ComponentPreview name="bank-input-supported-banks" />
+### RTL [#rtl]
+
+Labels, descriptions, and bank names follow the surrounding RTL interface while the card and Shaba values remain intentionally LTR. Persian digits are normalized during input.
+
+<ComponentPreview name="bank-input-rtl" direction="rtl" />
 
 ## API Reference
 

--- a/apps/web/content/docs/components/date-picker.mdx
+++ b/apps/web/content/docs/components/date-picker.mdx
@@ -10,20 +10,20 @@ Use `DatePicker` for the common path and `DateTimePicker` when date and time bel
 <LastEdited path="apps/web/content/docs/components/date-picker.mdx" />
 
 <Credits
-          sources={[
-            {
-              label: "shadcn/ui",
-              href: "https://ui.shadcn.com/docs/components/date-picker",
-            },
-          ]}
-          changed
-          changes={[
-            "Replaced shadcn's chrono-node natural-language input example with parseDate/formatDate + toLatinDigits from this repo's persian-date utility (no chrono-node dependency here)",
-            "Uses this repo's own Calendar (Jalali/Gregorian switchable via calendarType) and Popover components instead of shadcn's react-day-picker Calendar",
-            "Added first-class DatePicker and DateTimePicker APIs with responsive presentation, SSR-safe today defaults, and draft/confirm behavior",
-            "Added Calendar Type toggle, hospital/hotel Reservation, and Field + zod-validated Form examples not present upstream",
-          ]}
-        />
+  sources={[
+    {
+      label: "shadcn/ui",
+      href: "https://ui.shadcn.com/docs/components/date-picker",
+    },
+  ]}
+  changed
+  changes={[
+    "Replaced shadcn's chrono-node natural-language input example with parseDate/formatDate + toLatinDigits from this repo's persian-date utility (no chrono-node dependency here)",
+    "Uses this repo's own Calendar (Jalali/Gregorian switchable via calendarType) and Popover components instead of shadcn's react-day-picker Calendar",
+    "Added first-class DatePicker and DateTimePicker APIs with responsive presentation, SSR-safe today defaults, and draft/confirm behavior",
+    "Added Calendar Type toggle, hospital/hotel Reservation, and Field + zod-validated Form examples not present upstream",
+  ]}
+/>
 
 ## Overview
 
@@ -33,7 +33,13 @@ Use `DatePicker` for the common path and `DateTimePicker` when date and time bel
 
 Install the complete picker family with one registry command. Its Calendar, TimePicker, Popover, and Drawer dependencies are installed automatically.
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/date-picker" packages="react-day-picker @daypicker/persian date-fns @base-ui/react" sourceName="date-picker" sourceTitle="components/ui/date-picker.tsx" sourceStep="Copy the Date Picker component source" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/date-picker"
+  packages="react-day-picker @daypicker/persian date-fns @base-ui/react"
+  sourceName="date-picker"
+  sourceTitle="components/ui/date-picker.tsx"
+  sourceStep="Copy the Date Picker component source"
+/>
 
 ## Usage
 
@@ -47,85 +53,101 @@ export function Example() {
 
 ## Examples
 
-<ExampleSection id="range"
-  title="Range"
-  description="Keep a controlled `DateRange` and pass `onSelect={setRange}` directly. The same single-calendar interaction appears in a Popover on desktop and a Drawer on mobile."
-  name="date-picker-range" />
+### Range [#range]
 
-<ExampleSection id="close-on-select"
-  title="Close on Select"
-  description="Control the Popover state and close it after a valid date is selected."
-  name="date-picker-close-on-select" />
+Keep a controlled `DateRange` and pass `onSelect={setRange}` directly. The same single-calendar interaction appears in a Popover on desktop and a Drawer on mobile.
 
-<ExampleSection id="controlled"
-  title="Controlled Value"
-  description="Own the selected date in application state when other fields, validation, or server mutations need to react to every committed change."
-  name="date-picker-controlled" />
+<ComponentPreview name="date-picker-range" />
 
-<ExampleSection id="constrained"
-  title="Constrained Dates"
-  description="Forward Calendar props to limit selection to a rolling seven-day booking window. The same pattern supports disabled weekdays, minimum dates, and maximum dates."
-  name="date-picker-constrained" />
+### Close on Select [#close-on-select]
 
-<ExampleSection id="confirmation"
-  title="Confirmation Modes"
-  description="Compare immediate commits with an explicit confirmation flow. Explicit mode is useful when changing the value has expensive side effects."
-  name="date-picker-confirmation" />
+Control the Popover state and close it after a valid date is selected.
 
-<ExampleSection id="custom-trigger"
-  title="Custom Trigger"
-  description="Use renderTrigger to replace the default field while retaining disclosure state, formatting, keyboard behavior, and responsive presentation."
-  name="date-picker-custom-trigger" />
+<ComponentPreview name="date-picker-close-on-select" />
 
-<ExampleSection id="presets-responsive"
-  title="Responsive Presets"
-  description="Combine controlled state, a responsive Popover/Drawer, and Calendar footer content to provide common dates without giving up free calendar selection."
-  name="date-picker-presets-responsive" />
+### Controlled Value [#controlled]
 
-<ExampleSection id="with-time"
-  title="With Time"
-  description="Adds a [Time Picker](/docs/components/time-picker) input below the Calendar. That input opens its own popover on desktop and a drawer on smaller screens, so the wheel is never cramped beneath the calendar."
-  name="date-picker-with-time" />
+Own the selected date in application state when other fields, validation, or server mutations need to react to every committed change.
 
-<ExampleSection id="responsive"
-  title="Fully Responsive"
-  description="One trigger opens the familiar Calendar-and-time Popover on desktop, then switches to a single Drawer containing both controls on smaller screens."
-  name="date-picker-responsive" />
+<ComponentPreview name="date-picker-controlled" />
 
-<ExampleSection id="time-advanced"
-  title="Advanced Time Options"
-  description="Combine a verbose date label with a 12-hour time wheel, Latin digits, seconds, and visible hour/minute/second headings."
-  name="date-picker-time-advanced" />
+### Constrained Dates [#constrained]
 
-<ExampleSection id="input"
-  title="Typed Input"
-  description="A plain text field the user can type a `yyyy/MM/dd` date into (Persian or Latin digits), parsed live with `parseDate` and `toLatinDigits`, kept in sync with a Calendar opened as a secondary picking method. Digits aren't converted while typing (so the cursor stays predictable) -- they're normalized to a consistent digit style on blur or Enter, once the value is done changing."
-  name="date-picker-input" />
+Forward Calendar props to limit selection to a rolling seven-day booking window. The same pattern supports disabled weekdays, minimum dates, and maximum dates.
 
-<ExampleSection id="date-of-birth"
-  title="Date of Birth"
-  description={"Use `captionLayout=\"dropdown\"` for fast year navigation and close the popover on select."}
-  name="date-picker-dob" />
+<ComponentPreview name="date-picker-constrained" />
 
-<ExampleSection id="calendar-type"
-  title="Calendar Type"
-  description="Thread `calendarType` down to Calendar and format the trigger's label with the matching calendar."
-  name="date-picker-calendar-type" />
+### Confirmation Modes [#confirmation]
 
-<ExampleSection id="miladi"
-  title="Miladi + LTR"
-  description="Use the Gregorian calendar with English labels, LTR direction, and a long-form trigger format while retaining the same responsive behavior."
-  name="date-picker-miladi" />
+Compare immediate commits with an explicit confirmation flow. Explicit mode is useful when changing the value has expensive side effects.
 
-<ExampleSection id="reservation"
-  title="Reservation"
-  description="A hotel/hospital-style booking form: a range Calendar wired to `validateRange` (minDays, maxDays, disablePast) for stay-length validation, and to [persian-holidays](/docs/utilities/persian-holidays) 's `getHolidaysInRange` to redden holiday cells."
-  name="date-picker-reservation" />
+<ComponentPreview name="date-picker-confirmation" />
 
-<ExampleSection id="zod-form"
-  title="Zod-Validated Form"
-  description="A form built with this repo's [Field](/docs/components/field) components, where a single date is validated with `zPersianDate` and a `{ from, to }` range with `zPersianDateRange` on submit, both driven by Popover+Calendar selection instead of free-text typing."
-  name="date-picker-zod" />
+### Custom Trigger [#custom-trigger]
+
+Use renderTrigger to replace the default field while retaining disclosure state, formatting, keyboard behavior, and responsive presentation.
+
+<ComponentPreview name="date-picker-custom-trigger" />
+
+### Responsive Presets [#presets-responsive]
+
+Combine controlled state, a responsive Popover/Drawer, and Calendar footer content to provide common dates without giving up free calendar selection.
+
+<ComponentPreview name="date-picker-presets-responsive" />
+
+### With Time [#with-time]
+
+Adds a [Time Picker](/docs/components/time-picker) input below the Calendar. That input opens its own popover on desktop and a drawer on smaller screens, so the wheel is never cramped beneath the calendar.
+
+<ComponentPreview name="date-picker-with-time" />
+
+### Fully Responsive [#responsive]
+
+One trigger opens the familiar Calendar-and-time Popover on desktop, then switches to a single Drawer containing both controls on smaller screens.
+
+<ComponentPreview name="date-picker-responsive" />
+
+### Advanced Time Options [#time-advanced]
+
+Combine a verbose date label with a 12-hour time wheel, Latin digits, seconds, and visible hour/minute/second headings.
+
+<ComponentPreview name="date-picker-time-advanced" />
+
+### Typed Input [#input]
+
+A plain text field the user can type a `yyyy/MM/dd` date into (Persian or Latin digits), parsed live with `parseDate` and `toLatinDigits`, kept in sync with a Calendar opened as a secondary picking method. Digits aren't converted while typing (so the cursor stays predictable) -- they're normalized to a consistent digit style on blur or Enter, once the value is done changing.
+
+<ComponentPreview name="date-picker-input" />
+
+### Date of Birth [#date-of-birth]
+
+Use `captionLayout="dropdown"` for fast year navigation and close the popover on select.
+
+<ComponentPreview name="date-picker-dob" />
+
+### Calendar Type [#calendar-type]
+
+Thread `calendarType` down to Calendar and format the trigger's label with the matching calendar.
+
+<ComponentPreview name="date-picker-calendar-type" />
+
+### Miladi + LTR [#miladi]
+
+Use the Gregorian calendar with English labels, LTR direction, and a long-form trigger format while retaining the same responsive behavior.
+
+<ComponentPreview name="date-picker-miladi" />
+
+### Reservation [#reservation]
+
+A hotel/hospital-style booking form: a range Calendar wired to `validateRange` (minDays, maxDays, disablePast) for stay-length validation, and to [persian-holidays](/docs/utilities/persian-holidays) 's `getHolidaysInRange` to redden holiday cells.
+
+<ComponentPreview name="date-picker-reservation" />
+
+### Zod-Validated Form [#zod-form]
+
+A form built with this repo's [Field](/docs/components/field) components, where a single date is validated with `zPersianDate` and a `{ from, to }` range with `zPersianDateRange` on submit, both driven by Popover+Calendar selection instead of free-text typing.
+
+<ComponentPreview name="date-picker-zod" />
 
 ### RTL
 

--- a/apps/web/content/docs/components/date-wheel-picker.mdx
+++ b/apps/web/content/docs/components/date-wheel-picker.mdx
@@ -3,20 +3,24 @@ title: "Date Wheel Picker"
 description: "An iOS-style year/month/day wheel-based date picker, switchable between the Shamsi and Gregorian calendars, with a responsive Popover-on-desktop, Drawer-on-mobile composition."
 ---
 
-import { dateWheelPickerApi, responsiveDateWheelPickerApi, responsiveDateWheelPickerContentApi } from "@/lib/api-data/date-wheel-picker"
+import {
+  dateWheelPickerApi,
+  responsiveDateWheelPickerApi,
+  responsiveDateWheelPickerContentApi,
+} from "@/lib/api-data/date-wheel-picker"
 
 A year/month/day wheel-based date picker, composed on top of Wheel Picker and persian-date, with a Popover-on-desktop and Drawer-on-mobile trigger for use inside a form field. Wheels don't loop by default — scrolling past December stays on December instead of wrapping back to January — but this is configurable via `loop`.
 
 <LastEdited path="apps/web/content/docs/components/date-wheel-picker.mdx" />
 
 <Credits
-          sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
-          changed
-          changes={[
-            "Not a shadcn/ui component — this is an original composition of this registry's own Wheel Picker, Popover, and Drawer, mirroring Time Picker's Popover-on-desktop/Drawer-on-mobile pattern for a calendar date instead of a time-of-day",
-            "Year/month/day options and month lengths (including Esfand's leap-year 29/30 day swing) come from this registry's persian-date utilities (toParts/fromParts/daysInMonth) rather than any hand-rolled calendar math",
-          ]}
-        />
+  sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
+  changed
+  changes={[
+    "Not a shadcn/ui component — this is an original composition of this registry's own Wheel Picker, Popover, and Drawer, mirroring Time Picker's Popover-on-desktop/Drawer-on-mobile pattern for a calendar date instead of a time-of-day",
+    "Year/month/day options and month lengths (including Esfand's leap-year 29/30 day swing) come from this registry's persian-date utilities (toParts/fromParts/daysInMonth) rather than any hand-rolled calendar math",
+  ]}
+/>
 
 ## Overview
 
@@ -24,7 +28,13 @@ A year/month/day wheel-based date picker, composed on top of Wheel Picker and pe
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/date-wheel-picker" packages="@ncdai/react-wheel-picker @base-ui/react" sourceName="date-wheel-picker" sourceTitle="components/ui/date-wheel-picker.tsx" sourceStep="Copy the Wheel Picker, Popover, Drawer, and Persian Date first" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/date-wheel-picker"
+  packages="@ncdai/react-wheel-picker @base-ui/react"
+  sourceName="date-wheel-picker"
+  sourceTitle="components/ui/date-wheel-picker.tsx"
+  sourceStep="Copy the Wheel Picker, Popover, Drawer, and Persian Date first"
+/>
 
 ## Usage
 
@@ -38,21 +48,26 @@ export function Example() {
 
 ## Examples
 
-<ExampleSection id="range"
-  title="Range"
-  description="Two Date Wheel Pickers for a membership period, with the start date capped so it can't land after the expiry date."
-  name="date-wheel-picker-range" />
-<ExampleSection id="step"
-  title="Step"
-  description="Set yearStep to a value greater than 1 for a coarse, decade-jump year wheel — useful for a rough birth-decade picker."
-  name="date-wheel-picker-step" />
-<ExampleSection id="loop"
-  title="Loop"
-  description="Wheels don't loop by default. Set loop to enable it if wrapping (e.g. scrolling past December back to January) fits your use case."
-  name="date-wheel-picker-loop" />
-<ExampleSection id="calendar-type"
-  title="Calendar Type"
-  name="date-wheel-picker-calendar-type" />
+### Range [#range]
+
+Two Date Wheel Pickers for a membership period, with the start date capped so it can't land after the expiry date.
+
+<ComponentPreview name="date-wheel-picker-range" />
+### Step [#step]
+
+Set yearStep to a value greater than 1 for a coarse, decade-jump year wheel — useful for a rough birth-decade picker.
+
+<ComponentPreview name="date-wheel-picker-step" />
+### Loop [#loop]
+
+Wheels don't loop by default. Set loop to enable it if wrapping (e.g. scrolling past December back to January) fits your use case.
+
+<ComponentPreview name="date-wheel-picker-loop" />
+### Calendar Type [#calendar-type]
+
+undefined
+
+<ComponentPreview name="date-wheel-picker-calendar-type" />
 
 ### Responsive
 
@@ -60,24 +75,32 @@ ResponsiveDateWheelPicker renders a Popover on desktop and a Drawer on mobile fr
 
 <ComponentPreview name="date-wheel-picker-responsive" />
 
-<ExampleSection id="responsive-dialog"
-  title="In a Responsive Dialog"
-  description="Date Wheel Picker embedded inside a Responsive Dialog panel for a date-of-birth flow — a Dialog on desktop, a bottom Drawer on mobile."
-  name="date-wheel-picker-responsive-dialog" />
-<ExampleSection id="responsive-menu"
-  title="In a Responsive Menu"
-  description="Date Wheel Picker embedded inside a Responsive Menu's content for a quick date filter — a Dropdown Menu on desktop, a bottom Drawer menu on mobile."
-  name="date-wheel-picker-responsive-menu" />
-<ExampleSection id="rtl"
-  title="RTL"
-  description="Persian month names and digits work naturally in RTL layouts."
-  name="date-wheel-picker-rtl"
-  direction="rtl" />
+### In a Responsive Dialog [#responsive-dialog]
+
+Date Wheel Picker embedded inside a Responsive Dialog panel for a date-of-birth flow — a Dialog on desktop, a bottom Drawer on mobile.
+
+<ComponentPreview name="date-wheel-picker-responsive-dialog" />
+### In a Responsive Menu [#responsive-menu]
+
+Date Wheel Picker embedded inside a Responsive Menu's content for a quick date filter — a Dropdown Menu on desktop, a bottom Drawer menu on mobile.
+
+<ComponentPreview name="date-wheel-picker-responsive-menu" />
+### RTL [#rtl]
+
+Persian month names and digits work naturally in RTL layouts.
+
+<ComponentPreview name="date-wheel-picker-rtl" direction="rtl" />
 
 ## API Reference
 
 <ApiReference title="DateWheelPicker" rows={dateWheelPickerApi} />
 
-<ApiReference title="ResponsiveDateWheelPicker" rows={responsiveDateWheelPickerApi} />
+<ApiReference
+  title="ResponsiveDateWheelPicker"
+  rows={responsiveDateWheelPickerApi}
+/>
 
-<ApiReference title="ResponsiveDateWheelPickerContent" rows={responsiveDateWheelPickerContentApi} />
+<ApiReference
+  title="ResponsiveDateWheelPickerContent"
+  rows={responsiveDateWheelPickerContentApi}
+/>

--- a/apps/web/content/docs/components/mobile-number-input.mdx
+++ b/apps/web/content/docs/components/mobile-number-input.mdx
@@ -18,7 +18,12 @@ A plain Iranian mobile number field — no carrier logo, no carrier detection. I
 
 Install the input, its normalization/validation utility, and the input-group primitives in one step.
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/mobile-number-input" packages="lucide-react" sourceName="mobile-number-input" sourceTitle="components/ui/mobile-number-input.tsx" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/mobile-number-input"
+  packages="lucide-react"
+  sourceName="mobile-number-input"
+  sourceTitle="components/ui/mobile-number-input.tsx"
+/>
 
 ## Usage
 
@@ -32,11 +37,11 @@ export function Example() {
 
 ## Examples
 
-<ExampleSection id="rtl"
-  title="RTL"
-  description="Labels and helper text follow the surrounding RTL interface while the phone value remains intentionally LTR. Persian digits and +98/98/0098 prefixes are normalized as you type or paste."
-  name="mobile-number-input-rtl"
-  direction="rtl" />
+### RTL [#rtl]
+
+Labels and helper text follow the surrounding RTL interface while the phone value remains intentionally LTR. Persian digits and +98/98/0098 prefixes are normalized as you type or paste.
+
+<ComponentPreview name="mobile-number-input-rtl" direction="rtl" />
 
 ## API Reference
 

--- a/apps/web/content/docs/components/time-picker.mdx
+++ b/apps/web/content/docs/components/time-picker.mdx
@@ -3,20 +3,24 @@ title: "Time Picker"
 description: "An hour/minute/second wheel-based time picker, with a responsive Popover-on-desktop, Drawer-on-mobile composition."
 ---
 
-import { responsiveTimePickerApi, responsiveTimePickerContentApi, timePickerApi } from "@/lib/api-data/time-picker"
+import {
+  responsiveTimePickerApi,
+  responsiveTimePickerContentApi,
+  timePickerApi,
+} from "@/lib/api-data/time-picker"
 
 An hour/minute/second wheel-based clock, composed on top of Wheel Picker, with a Popover-on-desktop and Drawer-on-mobile trigger for use inside a form field. To pick a date and time together, see [Date Picker's With Time example](/docs/components/date-picker#with-time).
 
 <LastEdited path="apps/web/content/docs/components/time-picker.mdx" />
 
 <Credits
-          sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
-          changed
-          changes={[
-            "Not a shadcn/ui component — shadcn's own Time Picker guide uses a native <input type=\"time\"> in a popover; this is an original composition of this registry's own Wheel Picker, Popover, and Drawer instead, following the same Popover-on-desktop/Drawer-on-mobile pattern as Responsive Dialog and Responsive Menu",
-            "Time-of-day is represented as a plain { hour, minute, second? } object rather than a Date, so it never needs a calendar date and stays free of SSR/hydration timing issues",
-          ]}
-        />
+  sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
+  changed
+  changes={[
+    "Not a shadcn/ui component — shadcn's own Time Picker guide uses a native <input type=\"time\"> in a popover; this is an original composition of this registry's own Wheel Picker, Popover, and Drawer instead, following the same Popover-on-desktop/Drawer-on-mobile pattern as Responsive Dialog and Responsive Menu",
+    "Time-of-day is represented as a plain { hour, minute, second? } object rather than a Date, so it never needs a calendar date and stays free of SSR/hydration timing issues",
+  ]}
+/>
 
 ## Overview
 
@@ -24,7 +28,13 @@ An hour/minute/second wheel-based clock, composed on top of Wheel Picker, with a
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/time-picker" packages="@ncdai/react-wheel-picker @base-ui/react" sourceName="time-picker" sourceTitle="components/ui/time-picker.tsx" sourceStep="Copy the Wheel Picker, Popover, and Drawer first" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/time-picker"
+  packages="@ncdai/react-wheel-picker @base-ui/react"
+  sourceName="time-picker"
+  sourceTitle="components/ui/time-picker.tsx"
+  sourceStep="Copy the Wheel Picker, Popover, and Drawer first"
+/>
 
 ## Usage
 
@@ -38,16 +48,21 @@ export function Example() {
 
 ## Examples
 
-<ExampleSection id="seconds"
-  title="Seconds"
-  description="Set showSeconds to add a third wheel column."
-  name="time-picker-seconds" />
-<ExampleSection id="12-hour"
-  title="12-Hour Format"
-  name="time-picker-12-hour" />
-<ExampleSection id="popover"
-  title="Popover"
-  name="time-picker-popover" />
+### Seconds [#seconds]
+
+Set showSeconds to add a third wheel column.
+
+<ComponentPreview name="time-picker-seconds" />
+### 12-Hour Format [#12-hour]
+
+undefined
+
+<ComponentPreview name="time-picker-12-hour" />
+### Popover [#popover]
+
+undefined
+
+<ComponentPreview name="time-picker-popover" />
 
 ### Responsive
 
@@ -55,15 +70,16 @@ ResponsiveTimePicker renders a Popover on desktop and a Drawer on mobile from on
 
 <ComponentPreview name="time-picker-responsive" />
 
-<ExampleSection id="range"
-  title="Range"
-  description="Two Time Pickers for a business-hours style range, with the from-time capped so it can't exceed the to-time."
-  name="time-picker-range" />
-<ExampleSection id="rtl"
-  title="RTL"
-  description="Persian labels and AM/PM abbreviations (ق.ظ / ب.ظ) work naturally in RTL layouts."
-  name="time-picker-rtl"
-  direction="rtl" />
+### Range [#range]
+
+Two Time Pickers for a business-hours style range, with the from-time capped so it can't exceed the to-time.
+
+<ComponentPreview name="time-picker-range" />
+### RTL [#rtl]
+
+Persian labels and AM/PM abbreviations (ق.ظ / ب.ظ) work naturally in RTL layouts.
+
+<ComponentPreview name="time-picker-rtl" direction="rtl" />
 
 ## API Reference
 
@@ -71,4 +87,7 @@ ResponsiveTimePicker renders a Popover on desktop and a Drawer on mobile from on
 
 <ApiReference title="ResponsiveTimePicker" rows={responsiveTimePickerApi} />
 
-<ApiReference title="ResponsiveTimePickerContent" rows={responsiveTimePickerContentApi} />
+<ApiReference
+  title="ResponsiveTimePickerContent"
+  rows={responsiveTimePickerContentApi}
+/>

--- a/apps/web/content/docs/components/wheel-picker.mdx
+++ b/apps/web/content/docs/components/wheel-picker.mdx
@@ -3,25 +3,28 @@ title: "Wheel Picker"
 description: "An iOS-like wheel picker with smooth inertia, infinite scrolling, and keyboard navigation."
 ---
 
-import { wheelPickerApi, wheelPickerWrapperApi } from "@/lib/api-data/wheel-picker"
+import {
+  wheelPickerApi,
+  wheelPickerWrapperApi,
+} from "@/lib/api-data/wheel-picker"
 
 A touch-friendly picker with natural momentum scrolling, infinite options, keyboard navigation, and type-ahead search.
 
 <LastEdited path="apps/web/content/docs/components/wheel-picker.mdx" />
 
 <Credits
-          sources={[
-            {
-              label: "Chánh Đại's React Wheel Picker",
-              href: "https://chanhdai.com/components/react-wheel-picker",
-            },
-          ]}
-          changed
-          changes={[
-            "Adds a gesture boundary that stops touch events from reaching a containing Drawer, so the picker's inertial scroll is not cancelled by swipe-to-dismiss",
-            "Uses a direction-isolated LTR picker surface so numeric wheels remain naturally ordered inside RTL interfaces",
-          ]}
-        />
+  sources={[
+    {
+      label: "Chánh Đại's React Wheel Picker",
+      href: "https://chanhdai.com/components/react-wheel-picker",
+    },
+  ]}
+  changed
+  changes={[
+    "Adds a gesture boundary that stops touch events from reaching a containing Drawer, so the picker's inertial scroll is not cancelled by swipe-to-dismiss",
+    "Uses a direction-isolated LTR picker surface so numeric wheels remain naturally ordered inside RTL interfaces",
+  ]}
+/>
 
 ## Overview
 
@@ -29,13 +32,17 @@ A touch-friendly picker with natural momentum scrolling, infinite options, keybo
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/wheel-picker" packages="@ncdai/react-wheel-picker" sourceName="wheel-picker" sourceTitle="components/ui/wheel-picker.tsx" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/wheel-picker"
+  packages="@ncdai/react-wheel-picker"
+  sourceName="wheel-picker"
+  sourceTitle="components/ui/wheel-picker.tsx"
+/>
 
 ## Usage
 
 ```tsx
 import {
-
   WheelPicker,
   WheelPickerWrapper,
   type WheelPickerOption,
@@ -58,23 +65,26 @@ export function Example() {
 
 ## Examples
 
-<ExampleSection id="dialog"
-  title="Inside a Dialog"
-  description="The wheel works normally when placed in a focus-trapped Dialog."
-  name="wheel-picker-dialog" />
-<ExampleSection id="drawer"
-  title="Inside a Drawer"
-  description="The wrapper isolates the wheel's touch gesture, preventing the Drawer from cancelling inertial scrolling."
-  name="wheel-picker-drawer" />
-<ExampleSection id="responsive-dialog"
-  title="Inside a Responsive Dialog"
-  description="On mobile this composition becomes a Drawer and retains the same protected wheel gesture."
-  name="wheel-picker-responsive-dialog" />
-<ExampleSection id="rtl"
-  title="RTL"
-  description="Persian labels work in RTL layouts while the wheel's scrolling surface keeps a predictable numeric direction."
-  name="wheel-picker-rtl"
-  direction="rtl" />
+### Inside a Dialog [#dialog]
+
+The wheel works normally when placed in a focus-trapped Dialog.
+
+<ComponentPreview name="wheel-picker-dialog" />
+### Inside a Drawer [#drawer]
+
+The wrapper isolates the wheel's touch gesture, preventing the Drawer from cancelling inertial scrolling.
+
+<ComponentPreview name="wheel-picker-drawer" />
+### Inside a Responsive Dialog [#responsive-dialog]
+
+On mobile this composition becomes a Drawer and retains the same protected wheel gesture.
+
+<ComponentPreview name="wheel-picker-responsive-dialog" />
+### RTL [#rtl]
+
+Persian labels work in RTL layouts while the wheel's scrolling surface keeps a predictable numeric direction.
+
+<ComponentPreview name="wheel-picker-rtl" direction="rtl" />
 
 ## API Reference
 

--- a/apps/web/content/docs/utilities/hitbox.mdx
+++ b/apps/web/content/docs/utilities/hitbox.mdx
@@ -10,9 +10,9 @@ Wrap an interactive element to extend its clickable area without changing its vi
 <LastEdited path="apps/web/content/docs/utilities/hitbox.mdx" />
 
 <Credits
-          sources={[{ label: "Dice UI", href: "https://diceui.com/" }]}
-          changed={false}
-        />
+  sources={[{ label: "Dice UI", href: "https://diceui.com/" }]}
+  changed={false}
+/>
 
 ## Overview
 
@@ -29,7 +29,7 @@ Hitbox preserves the child's semantics while adding an invisible touch target ar
 </TabsList>
 
 <TabsContent value="cli" className="mt-4">
-<CopyCommand command="npx shadcn@latest add @persianlabsui/hitbox" />
+  <CopyCommand command="npx shadcn@latest add @persianlabsui/hitbox" />
 </TabsContent>
 
 <TabsContent value="manual" className="mt-4">
@@ -53,29 +53,33 @@ Import Hitbox and wrap it around any interactive element.
 ```tsx
 import { Hitbox } from "@/components/ui/hitbox"
 
-<Hitbox>
+;<Hitbox>
   <Button />
 </Hitbox>
 ```
 
 ## Examples
 
-<ExampleSection id="sizes"
-  title="Sizes"
-  description="Control how far the hitbox extends. Use sm, default, lg, or a custom CSS value."
-  name="hitbox-sizes" />
-<ExampleSection id="positions"
-  title="Positions"
-  description="Limit the extended hitbox to one or more sides of the element."
-  name="hitbox-positions" />
-<ExampleSection id="radii"
-  title="Radii"
-  description="Match the extended area to the child’s corner radius."
-  name="hitbox-radii" />
-<ExampleSection id="debug"
-  title="Debug mode"
-  description="Enable debug to visualize the normally invisible hitbox while developing."
-  name="hitbox-debug" />
+### Sizes [#sizes]
+
+Control how far the hitbox extends. Use sm, default, lg, or a custom CSS value.
+
+<ComponentPreview name="hitbox-sizes" />
+### Positions [#positions]
+
+Limit the extended hitbox to one or more sides of the element.
+
+<ComponentPreview name="hitbox-positions" />
+### Radii [#radii]
+
+Match the extended area to the child’s corner radius.
+
+<ComponentPreview name="hitbox-radii" />
+### Debug mode [#debug]
+
+Enable debug to visualize the normally invisible hitbox while developing.
+
+<ComponentPreview name="hitbox-debug" />
 
 ## API Reference
 

--- a/apps/web/content/docs/utilities/persian-date.mdx
+++ b/apps/web/content/docs/utilities/persian-date.mdx
@@ -3,7 +3,14 @@ title: "Persian Date"
 description: "Jalali/Gregorian date utilities built on date-fns and date-fns-jalali: formatting, parsing, conversion, ranges, and digit conversion, switchable with a calendarType prop."
 ---
 
-import { arithmeticApi, comparisonsRangesApi, conversionApi, dateOptionsApi, digitsApi, formattingParsingApi } from "@/lib/api-data/persian-date"
+import {
+  arithmeticApi,
+  comparisonsRangesApi,
+  conversionApi,
+  dateOptionsApi,
+  digitsApi,
+  formattingParsingApi,
+} from "@/lib/api-data/persian-date"
 
 A single set of date utilities that works across the Jalali (Solar Hijri) and Gregorian calendars: format and parse dates, convert between calendars, do calendar-aware arithmetic, and validate reservation-style ranges — all built on `date-fns` and `date-fns-jalali`.
 
@@ -15,7 +22,13 @@ A single set of date utilities that works across the Jalali (Solar Hijri) and Gr
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/persian-date" sourceName="persian-date" sourceKind="lib" sourceTitle="lib/persian-date.ts" sourceStep="Copy the source into your project" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/persian-date"
+  sourceName="persian-date"
+  sourceKind="lib"
+  sourceTitle="lib/persian-date.ts"
+  sourceStep="Copy the source into your project"
+/>
 
 ## Usage
 
@@ -33,38 +46,46 @@ formatDate(checkOut, "d MMMM", { calendarType: "miladi" }) // Gregorian
 
 ## Examples
 
-<ExampleSection id="parsing"
-  title="Parsing"
-  description="parseDate normalizes Persian/Arabic-Indic digits before parsing, and returns null instead of an invalid Date on failure."
-  name="persian-date-parsing" />
-<ExampleSection id="conversion"
-  title="Shamsi ↔ Miladi conversion"
-  description="toParts/fromParts (and their toShamsi/toMiladi/fromShamsi/fromMiladi shorthands) round-trip a Date through calendar fields without losing precision."
-  name="persian-date-conversion" />
-<ExampleSection id="arithmetic"
-  title="Calendar-aware arithmetic"
-  description="addMonths and addYears respect the active calendar's month lengths — adding a month to the end of Esfand behaves differently than adding one to the Gregorian February."
-  name="persian-date-arithmetic" />
-<ExampleSection id="boundaries"
-  title="Start / end of week, month, year"
-  description="startOfWeek/endOfWeek default to a Saturday-start week for shamsi (Sunday for miladi); startOfMonth/endOfMonth and startOfYear/endOfYear follow the same calendar-aware pattern."
-  name="persian-date-boundaries" />
-<ExampleSection id="leap-year"
-  title="Leap year & days in month"
-  description="isLeapYear and daysInMonth resolve Esfand's 29 vs. 30 days for the Jalali calendar."
-  name="persian-date-leap-year" />
-<ExampleSection id="comparisons"
-  title="Comparisons"
-  description="isToday, isPast, and isFuture classify a date relative to the current moment."
-  name="persian-date-comparisons" />
-<ExampleSection id="range"
-  title="Date range"
-  description="eachDayOfRange lists every day in an inclusive range; isWithinRange checks whether a given date falls inside it."
-  name="persian-date-range" />
-<ExampleSection id="reservation"
-  title="Range validation (reservation form)"
-  description="validateRange is built for hospital/hotel-style booking forms: it checks ordering, minimum/maximum stay length, past dates, and specific blocked dates, returning a machine-readable reason you can map to a message."
-  name="persian-date-reservation" />
+### Parsing [#parsing]
+
+parseDate normalizes Persian/Arabic-Indic digits before parsing, and returns null instead of an invalid Date on failure.
+
+<ComponentPreview name="persian-date-parsing" />
+### Shamsi ↔ Miladi conversion [#conversion]
+
+toParts/fromParts (and their toShamsi/toMiladi/fromShamsi/fromMiladi shorthands) round-trip a Date through calendar fields without losing precision.
+
+<ComponentPreview name="persian-date-conversion" />
+### Calendar-aware arithmetic [#arithmetic]
+
+addMonths and addYears respect the active calendar's month lengths — adding a month to the end of Esfand behaves differently than adding one to the Gregorian February.
+
+<ComponentPreview name="persian-date-arithmetic" />
+### Start / end of week, month, year [#boundaries]
+
+startOfWeek/endOfWeek default to a Saturday-start week for shamsi (Sunday for miladi); startOfMonth/endOfMonth and startOfYear/endOfYear follow the same calendar-aware pattern.
+
+<ComponentPreview name="persian-date-boundaries" />
+### Leap year & days in month [#leap-year]
+
+isLeapYear and daysInMonth resolve Esfand's 29 vs. 30 days for the Jalali calendar.
+
+<ComponentPreview name="persian-date-leap-year" />
+### Comparisons [#comparisons]
+
+isToday, isPast, and isFuture classify a date relative to the current moment.
+
+<ComponentPreview name="persian-date-comparisons" />
+### Date range [#range]
+
+eachDayOfRange lists every day in an inclusive range; isWithinRange checks whether a given date falls inside it.
+
+<ComponentPreview name="persian-date-range" />
+### Range validation (reservation form) [#reservation]
+
+validateRange is built for hospital/hotel-style booking forms: it checks ordering, minimum/maximum stay length, past dates, and specific blocked dates, returning a machine-readable reason you can map to a message.
+
+<ComponentPreview name="persian-date-reservation" />
 
 ### RTL
 

--- a/apps/web/content/docs/utilities/persian-holidays.mdx
+++ b/apps/web/content/docs/utilities/persian-holidays.mdx
@@ -3,27 +3,32 @@ title: "Persian Holidays"
 description: "Official/religious/cultural Iranian holiday lookup for a date, range, or year, resolving Jalali, Gregorian, and tabular-Hijri entries."
 ---
 
-import { getHolidaysOptionsApi, holidaysApi, lowLevelHijriApi, resolvedHolidayApi } from "@/lib/api-data/persian-holidays"
+import {
+  getHolidaysOptionsApi,
+  holidaysApi,
+  lowLevelHijriApi,
+  resolvedHolidayApi,
+} from "@/lib/api-data/persian-holidays"
 
 Look up official, religious, and cultural Iranian holidays for a single date, a range, or a whole calendar year. Jalali and Gregorian entries resolve to an exact date; Hijri (lunar) entries are resolved with a tabular approximation and flagged `approximate: true`, since Iran announces religious holidays by moon sighting.
 
 <LastEdited path="apps/web/content/docs/utilities/persian-holidays.mdx" />
 
 <Credits
-          sources={[
-            {
-              label: "BaseMax/persian-holidays-api",
-              href: "https://github.com/BaseMax/persian-holidays-api",
-            },
-          ]}
-          changed
-          changes={[
-            "Trimmed the dataset to recurring month/day entries (dropped year-specific fields).",
-            "Converted month names to numeric, 1-indexed month indices.",
-            "Added a tabular Hijri→Gregorian resolution with approximate flagging for lunar entries.",
-            "Added official/includeUnofficial filtering so callers can request only official days off.",
-          ]}
-        />
+  sources={[
+    {
+      label: "BaseMax/persian-holidays-api",
+      href: "https://github.com/BaseMax/persian-holidays-api",
+    },
+  ]}
+  changed
+  changes={[
+    "Trimmed the dataset to recurring month/day entries (dropped year-specific fields).",
+    "Converted month names to numeric, 1-indexed month indices.",
+    "Added a tabular Hijri→Gregorian resolution with approximate flagging for lunar entries.",
+    "Added official/includeUnofficial filtering so callers can request only official days off.",
+  ]}
+/>
 
 ## Overview
 
@@ -31,7 +36,13 @@ Look up official, religious, and cultural Iranian holidays for a single date, a 
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/persian-holidays" sourceName="persian-holidays" sourceKind="lib" sourceTitle="lib/persian-holidays.ts" sourceStep="Copy the source into your project" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/persian-holidays"
+  sourceName="persian-holidays"
+  sourceKind="lib"
+  sourceTitle="lib/persian-holidays.ts"
+  sourceStep="Copy the source into your project"
+/>
 
 ## Usage
 
@@ -46,22 +57,26 @@ const isTodayOff = isHoliday(today())
 
 ## Examples
 
-<ExampleSection id="lookup"
-  title="Lookup a date"
-  description="isHoliday and getHolidayInfo check whether a specific date is a holiday, and list every matching entry."
-  name="persian-holidays-lookup" />
-<ExampleSection id="unofficial"
-  title="Official vs. unofficial"
-  description="By default only official days off are returned. Pass includeUnofficial: true to also list commemorative occasions."
-  name="persian-holidays-unofficial" />
-<ExampleSection id="calendar"
-  title="Calendar grid"
-  description="getHolidaysInRange over a month's boundaries makes it easy to color holiday cells in a calendar grid."
-  name="persian-holidays-calendar" />
-<ExampleSection id="approximate"
-  title="Hijri approximation"
-  description="Lunar (hijri) holidays resolve through a tabular approximation and come back with approximate: true — treat these dates as a best-effort estimate, not an announcement."
-  name="persian-holidays-approximate" />
+### Lookup a date [#lookup]
+
+isHoliday and getHolidayInfo check whether a specific date is a holiday, and list every matching entry.
+
+<ComponentPreview name="persian-holidays-lookup" />
+### Official vs. unofficial [#unofficial]
+
+By default only official days off are returned. Pass includeUnofficial: true to also list commemorative occasions.
+
+<ComponentPreview name="persian-holidays-unofficial" />
+### Calendar grid [#calendar]
+
+getHolidaysInRange over a month's boundaries makes it easy to color holiday cells in a calendar grid.
+
+<ComponentPreview name="persian-holidays-calendar" />
+### Hijri approximation [#approximate]
+
+Lunar (hijri) holidays resolve through a tabular approximation and come back with approximate: true — treat these dates as a best-effort estimate, not an announcement.
+
+<ComponentPreview name="persian-holidays-approximate" />
 
 ### RTL
 

--- a/apps/web/content/docs/utilities/use-countdown.mdx
+++ b/apps/web/content/docs/utilities/use-countdown.mdx
@@ -3,27 +3,30 @@ title: "useCountdown"
 description: "A timer-aligned React countdown hook for ISO-8601 target dates, with formatted output and overdue state."
 ---
 
-import { countdownResultApi, useCountdownApi } from "@/lib/api-data/use-countdown"
+import {
+  countdownResultApi,
+  useCountdownApi,
+} from "@/lib/api-data/use-countdown"
 
 A countdown hook for deadlines, launches, reservations, and temporary offers. It updates on the next clock-second boundary, returns a display-ready value, and continues tracking elapsed time after a deadline passes.
 
 <LastEdited path="apps/web/content/docs/utilities/use-countdown.mdx" />
 
 <Credits
-          sources={[
-            {
-              label: "initial implementation supplied by a project contributor",
-              href: "https://github.com/persianlabs/ui",
-            },
-          ]}
-          changed
-          changes={[
-            "Replaced a drifting interval with second-boundary-aligned timeouts.",
-            "Added invalid-date handling so null and malformed targets safely return null.",
-            "Changed rounded remaining time to ceiling semantics so a future target does not show zero early.",
-            "Added documented result types and examples for formatted, segmented, paused, overdue, and RTL countdowns.",
-          ]}
-        />
+  sources={[
+    {
+      label: "initial implementation supplied by a project contributor",
+      href: "https://github.com/persianlabs/ui",
+    },
+  ]}
+  changed
+  changes={[
+    "Replaced a drifting interval with second-boundary-aligned timeouts.",
+    "Added invalid-date handling so null and malformed targets safely return null.",
+    "Changed rounded remaining time to ceiling semantics so a future target does not show zero early.",
+    "Added documented result types and examples for formatted, segmented, paused, overdue, and RTL countdowns.",
+  ]}
+/>
 
 ## Overview
 
@@ -31,7 +34,13 @@ A countdown hook for deadlines, launches, reservations, and temporary offers. It
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/use-countdown" sourceName="use-countdown" sourceKind="hook" sourceTitle="hooks/use-countdown.ts" sourceStep="Copy the source into your project" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/use-countdown"
+  sourceName="use-countdown"
+  sourceKind="hook"
+  sourceTitle="hooks/use-countdown.ts"
+  sourceStep="Copy the source into your project"
+/>
 
 ## Usage
 
@@ -64,22 +73,26 @@ const countdown = useCountdown(isTimerActive ? endsAt : null)
 
 ## Examples
 
-<ExampleSection id="parts"
-  title="Time units"
-  description="Use the individual units when each part needs its own visual treatment. Hours can exceed 24."
-  name="use-countdown-parts" />
-<ExampleSection id="reset"
-  title="Pause and play"
-  description="Pause a countdown without losing its remaining duration, then resume it from exactly where it stopped."
-  name="use-countdown-reset" />
-<ExampleSection id="overdue"
-  title="Overdue targets"
-  description="After the target passes, formatted remains absolute while totalSeconds is negative and isOverdue becomes true."
-  name="use-countdown-overdue" />
-<ExampleSection id="otp"
-  title="OTP resend"
-  description="Keep the resend action unavailable until the cooldown expires, then start a fresh countdown whenever another code is sent."
-  name="use-countdown-otp" />
+### Time units [#parts]
+
+Use the individual units when each part needs its own visual treatment. Hours can exceed 24.
+
+<ComponentPreview name="use-countdown-parts" />
+### Pause and play [#reset]
+
+Pause a countdown without losing its remaining duration, then resume it from exactly where it stopped.
+
+<ComponentPreview name="use-countdown-reset" />
+### Overdue targets [#overdue]
+
+After the target passes, formatted remains absolute while totalSeconds is negative and isOverdue becomes true.
+
+<ComponentPreview name="use-countdown-overdue" />
+### OTP resend [#otp]
+
+Keep the resend action unavailable until the cooldown expires, then start a fresh countdown whenever another code is sent.
+
+<ComponentPreview name="use-countdown-otp" />
 
 ### RTL
 

--- a/apps/web/content/docs/utilities/use-date.mdx
+++ b/apps/web/content/docs/utilities/use-date.mdx
@@ -15,7 +15,13 @@ A ticking clock hook built on `persian-date` and `persian-holidays`. Returns the
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/use-date" sourceName="use-date" sourceKind="hook" sourceTitle="hooks/use-date.ts" sourceStep="Copy the source into your project" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/use-date"
+  sourceName="use-date"
+  sourceKind="hook"
+  sourceTitle="hooks/use-date.ts"
+  sourceStep="Copy the source into your project"
+/>
 
 ## Usage
 
@@ -31,32 +37,42 @@ function Clock() {
 
   const { formatted, isHoliday } = date
 
-  return <span>{formatted}{isHoliday ? " (تعطیل)" : ""}</span>
+  return (
+    <span>
+      {formatted}
+      {isHoliday ? " (تعطیل)" : ""}
+    </span>
+  )
 }
 ```
 
 ## Examples
 
-<ExampleSection id="miladi"
-  title="Gregorian mode"
-  description={"Set calendarType: \"miladi\" to switch the formatted output and returned fields to the Gregorian calendar."}
-  name="use-date-miladi" />
-<ExampleSection id="pattern"
-  title="Custom pattern & digits"
-  description="pattern accepts any date-fns token, and digits lets you force Latin digits even in the shamsi calendar."
-  name="use-date-pattern" />
-<ExampleSection id="static"
-  title="Disabling the tick"
-  description="Pass interval: 0 to read the time once on mount without setting up a timer — useful for a one-shot timestamp."
-  name="use-date-static" />
-<ExampleSection id="holiday"
-  title="Holiday flagging"
-  description="checkHoliday: true flags the current date against the built-in Iranian holiday dataset and lists any matching entries."
-  name="use-date-holiday" />
-<ExampleSection id="navigator"
-  title="Day/week/month/year navigator"
-  description="A selected-date navigator built from persian-date's addDays/addWeeks/addMonths/addYears -- a common pattern for calendar/agenda UIs that step through time by different units."
-  name="use-date-navigator" />
+### Gregorian mode [#miladi]
+
+Set calendarType: "miladi" to switch the formatted output and returned fields to the Gregorian calendar.
+
+<ComponentPreview name="use-date-miladi" />
+### Custom pattern & digits [#pattern]
+
+pattern accepts any date-fns token, and digits lets you force Latin digits even in the shamsi calendar.
+
+<ComponentPreview name="use-date-pattern" />
+### Disabling the tick [#static]
+
+Pass interval: 0 to read the time once on mount without setting up a timer — useful for a one-shot timestamp.
+
+<ComponentPreview name="use-date-static" />
+### Holiday flagging [#holiday]
+
+checkHoliday: true flags the current date against the built-in Iranian holiday dataset and lists any matching entries.
+
+<ComponentPreview name="use-date-holiday" />
+### Day/week/month/year navigator [#navigator]
+
+A selected-date navigator built from persian-date's addDays/addWeeks/addMonths/addYears -- a common pattern for calendar/agenda UIs that step through time by different units.
+
+<ComponentPreview name="use-date-navigator" />
 
 ### RTL
 

--- a/apps/web/content/docs/utilities/use-time-ago.mdx
+++ b/apps/web/content/docs/utilities/use-time-ago.mdx
@@ -1,9 +1,14 @@
 ---
 title: "useTimeAgo"
-description: "A reactive relative-time formatter (\"۲ روز پیش\" / \"2 days ago\") with built-in Persian and English message tables."
+description: 'A reactive relative-time formatter ("۲ روز پیش" / "2 days ago") with built-in Persian and English message tables.'
 ---
 
-import { builtInTablesApi, formatTimeAgoApi, timeAgoMessagesApi, useTimeAgoApi } from "@/lib/api-data/use-time-ago"
+import {
+  builtInTablesApi,
+  formatTimeAgoApi,
+  timeAgoMessagesApi,
+  useTimeAgoApi,
+} from "@/lib/api-data/use-time-ago"
 
 Formats the distance between a timestamp and now — &ldquo;همین الان&rdquo;, &ldquo;۵ دقیقه پیش&rdquo;, &ldquo;دیروز&rdquo; — and keeps that string current by re-rendering on an interval. Works with Persian or English messages, and can fall back to an absolute date past a threshold.
 
@@ -15,7 +20,13 @@ Formats the distance between a timestamp and now — &ldquo;همین الان&rd
 
 ## Installation
 
-<InstallTabs command="npx shadcn@latest add @persianlabsui/use-time-ago" sourceName="use-time-ago" sourceKind="hook" sourceTitle="hooks/use-time-ago.ts" sourceStep="Copy the source into your project" />
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/use-time-ago"
+  sourceName="use-time-ago"
+  sourceKind="hook"
+  sourceTitle="hooks/use-time-ago.ts"
+  sourceStep="Copy the source into your project"
+/>
 
 ## Usage
 
@@ -31,26 +42,31 @@ function LastSeen({ at }: { at: string }) {
 
 ## Examples
 
-<ExampleSection id="en"
-  title="English locale"
-  description={"Pass locale: \"en\" to switch to the built-in English message table."}
-  name="use-time-ago-en" />
-<ExampleSection id="interval"
-  title="Custom update interval"
-  description={"updateInterval controls how often the string re-renders — shorten it for a live-feeling \"seconds ago\" counter."}
-  name="use-time-ago-interval" />
-<ExampleSection id="max"
-  title="Falling back to a full date"
-  description="max caps how far back the relative format goes; beyond it, fullDateFormatter renders an absolute date instead."
-  name="use-time-ago-max" />
-<ExampleSection id="second"
-  title="Showing seconds"
-  description={"By default, anything under a minute collapses to \"just now\". showSecond keeps the seconds unit instead."}
-  name="use-time-ago-second" />
-<ExampleSection id="messages"
-  title="Custom messages"
-  description="Supply your own TimeAgoMessages table to fully control the wording for every unit."
-  name="use-time-ago-messages" />
+### English locale [#en]
+
+Pass locale: "en" to switch to the built-in English message table.
+
+<ComponentPreview name="use-time-ago-en" />
+### Custom update interval [#interval]
+
+updateInterval controls how often the string re-renders — shorten it for a live-feeling "seconds ago" counter.
+
+<ComponentPreview name="use-time-ago-interval" />
+### Falling back to a full date [#max]
+
+max caps how far back the relative format goes; beyond it, fullDateFormatter renders an absolute date instead.
+
+<ComponentPreview name="use-time-ago-max" />
+### Showing seconds [#second]
+
+By default, anything under a minute collapses to "just now". showSecond keeps the seconds unit instead.
+
+<ComponentPreview name="use-time-ago-second" />
+### Custom messages [#messages]
+
+Supply your own TimeAgoMessages table to fully control the wording for every unit.
+
+<ComponentPreview name="use-time-ago-messages" />
 
 ### RTL
 


### PR DESCRIPTION
## Summary

Example subsections rendered via `<ExampleSection>` never appeared in the page TOC: fumadocs extracts headings from markdown `heading` nodes at build time, and ExampleSection's `<h3>` only exists at runtime. PR #53 fixed calendar.mdx; this applies the same conversion everywhere.

- Converted every remaining `<ExampleSection>` (68 blocks across 12 component/utility pages) into real `###` headings + description paragraph + `<ComponentPreview>`
- All original anchor ids are preserved with fumadocs' trailing `[#id]` heading syntax, so deep links like `/docs/components/date-picker#with-time` keep working
- Affected pages: bank-input, date-picker, date-wheel-picker, mobile-number-input, time-picker, wheel-picker, hitbox, persian-date, persian-holidays, use-countdown, use-date, use-time-ago
- Prettier also normalized pre-existing unformatted JSX in those files

## Verification

- Audit script confirms zero `<ExampleSection>` remain and every example preview now sits under an `h3`
- `bun scripts/check-mdx-components.mts`, `bun run lint`, `bun run typecheck` pass in apps/web
