### PR TITLE
feat(sidebar): composable collapsible sidebar with RTL support

### DIFF
--- a/apps/web/app/docs/components/sidebar/opengraph-image.tsx
+++ b/apps/web/app/docs/components/sidebar/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { SidebarPreview } from "@/lib/component-opengraph-previews"
+import { buildOgImage, ogImageSize } from "@/lib/og-image"
+
+export const alt = "Sidebar - PersianLabs UI"
+export const size = ogImageSize
+export const contentType = "image/png"
+
+export default function OpengraphImage() {
+  return buildOgImage(
+    "Sidebar",
+    "A composable, collapsible application sidebar with mobile drawer, tooltips, and RTL support. Built on Base UI.",
+    <SidebarPreview />
+  )
+}

--- a/apps/web/components/component-preview.tsx
+++ b/apps/web/components/component-preview.tsx
@@ -153,8 +153,8 @@ export function ComponentPreview({
         ? "min-h-0 flex-1 [align-items:safe_center] justify-center overflow-auto p-6 pb-28 sm:p-12 sm:pb-28"
         : "min-h-0 flex-1 items-stretch justify-stretch overflow-auto p-0"
       : kind === "component"
-        ? "min-h-56 items-center justify-center p-8 pt-12"
-        : "min-h-56 items-stretch justify-stretch p-0"
+        ? "min-h-56 items-center justify-center p-8"
+        : "h-[440px] min-h-56 items-stretch justify-stretch p-0"
   )
 
   return (
@@ -165,34 +165,37 @@ export function ComponentPreview({
         "relative flex w-full flex-col overflow-hidden rounded-2xl border border-border",
         fullscreen &&
           "fixed inset-0 z-50 min-h-svh rounded-none border-0 bg-background",
-        className
+        // Page-level spacing (mt-4) belongs to the embedded card only --
+        // carrying it into the fixed fullscreen layer offsets the viewport.
+        !fullscreen && className
       )}
     >
-      {!fullscreen && !forcedDir && (
-        <button
-          type="button"
-          onClick={toggleDirection}
-          aria-label="Toggle preview direction"
-          className="absolute end-12 top-3 z-10 inline-flex h-7 w-18 shrink-0 items-center justify-center gap-1.5 rounded-md border border-border bg-background text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
-        >
-          {resolvedDir === "ltr" ? (
-            <TextAlignStart className="size-3.5" />
-          ) : (
-            <TextAlignEnd className="size-3.5" />
-          )}
-          {resolvedDir.toUpperCase()}
-        </button>
-      )}
-
       {!fullscreen && (
-        <button
-          type="button"
-          onClick={openFullscreen}
-          aria-label="Open fullscreen preview"
-          className="absolute end-3 top-3 z-10 inline-flex size-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
-        >
-          <Expand className="size-3.5" />
-        </button>
+        <div className="flex items-center justify-end gap-1 border-b border-border px-3 py-2">
+          {!forcedDir && (
+            <button
+              type="button"
+              onClick={toggleDirection}
+              aria-label="Toggle preview direction"
+              className="inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
+            >
+              {resolvedDir === "ltr" ? (
+                <TextAlignStart className="size-3.5" />
+              ) : (
+                <TextAlignEnd className="size-3.5" />
+              )}
+              {resolvedDir.toUpperCase()}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={openFullscreen}
+            aria-label="Open fullscreen preview"
+            className="inline-flex size-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.97]"
+          >
+            <Expand className="size-3.5" />
+          </button>
+        </div>
       )}
 
       <div
@@ -240,8 +243,8 @@ export function ComponentPreview({
 
       {fullscreen && (
         <>
-          <div className="fixed inset-x-0 bottom-5 z-10 flex justify-center px-4">
-            <div className="flex items-center gap-1 rounded-lg border border-border bg-popover/95 p-1 text-xs text-muted-foreground shadow-lg backdrop-blur-sm">
+          <div className="pointer-events-none fixed inset-x-0 bottom-5 z-10 flex justify-center px-4">
+            <div className="pointer-events-auto flex items-center gap-1 rounded-lg border border-border bg-popover/95 p-1 text-xs text-muted-foreground shadow-lg backdrop-blur-sm">
               <PreviewControl
                 onClick={closeFullscreen}
                 shortcut="Esc"

--- a/apps/web/components/examples/__map__.ts
+++ b/apps/web/components/examples/__map__.ts
@@ -355,6 +355,8 @@ export const exampleLoaders: Record<string, () => Promise<React.ComponentType>> 
   "sheet-demo": () => import("@/components/examples/sheet-demo").then((m) => m.SheetDemoExample),
   "sheet-rtl": () => import("@/components/examples/sheet-rtl").then((m) => m.SheetRtlExample),
   "sheet-side": () => import("@/components/examples/sheet-side").then((m) => m.SheetSideExample),
+  "sidebar-demo": () => import("@/components/examples/sidebar-demo").then((m) => m.SidebarDemoExample),
+  "sidebar-rtl": () => import("@/components/examples/sidebar-rtl").then((m) => m.SidebarRtlExample),
   "skeleton-card": () => import("@/components/examples/skeleton-card").then((m) => m.SkeletonCardExample),
   "skeleton-demo": () => import("@/components/examples/skeleton-demo").then((m) => m.SkeletonDemoExample),
   "skeleton-rtl": () => import("@/components/examples/skeleton-rtl").then((m) => m.SkeletonRtlExample),
@@ -806,6 +808,8 @@ export type ExampleMap = {
   "sheet-demo": React.ComponentType;
   "sheet-rtl": React.ComponentType;
   "sheet-side": React.ComponentType;
+  "sidebar-demo": React.ComponentType;
+  "sidebar-rtl": React.ComponentType;
   "skeleton-card": React.ComponentType;
   "skeleton-demo": React.ComponentType;
   "skeleton-rtl": React.ComponentType;

--- a/apps/web/components/examples/sidebar-demo.tsx
+++ b/apps/web/components/examples/sidebar-demo.tsx
@@ -1,0 +1,351 @@
+"use client"
+
+import * as React from "react"
+import {
+  AudioWaveform,
+  Bot,
+  ChevronRight,
+  ChevronsUpDown,
+  CreditCard,
+  Folder,
+  Forward,
+  Frame,
+  GalleryVerticalEnd,
+  LogOut,
+  Map,
+  MoreHorizontal,
+  PieChart,
+  Plus,
+  Settings2,
+  SquareTerminal,
+  Trash2,
+} from "lucide-react"
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@workspace/ui/components/avatar"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@workspace/ui/components/collapsible"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuGroup,
+  DropdownMenuGroupLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+  useSidebar,
+} from "@workspace/ui/components/sidebar"
+
+const data = {
+  user: {
+    name: "taymaz",
+    email: "taymazak1382@gmail.com",
+    avatar: "/avatars/shadcn.jpg",
+  },
+  teams: [
+    { name: "Persian Labs", logo: GalleryVerticalEnd, plan: "Enterprise" },
+    { name: "Acme Corp.", logo: AudioWaveform, plan: "Startup" },
+  ],
+  navMain: [
+    {
+      title: "Playground",
+      icon: SquareTerminal,
+      isActive: true,
+      items: ["History", "Starred", "Settings"],
+    },
+    {
+      title: "Models",
+      icon: Bot,
+      items: ["Genesis", "Explorer", "Quantum"],
+    },
+    {
+      title: "Documentation",
+      icon: Frame,
+      items: ["Introduction", "Get Started", "Tutorials"],
+    },
+    {
+      title: "Settings",
+      icon: Settings2,
+      items: ["General", "Team", "Billing"],
+    },
+  ],
+  projects: [
+    { name: "Design Engineering", icon: Frame },
+    { name: "Sales & Marketing", icon: PieChart },
+    { name: "Travel", icon: Map },
+  ],
+}
+
+function TeamSwitcher() {
+  const { isMobile } = useSidebar()
+  const [activeTeam, setActiveTeam] = React.useState(data.teams[0])
+
+  if (!activeTeam) return null
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                size="lg"
+                className="data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground"
+              />
+            }
+          >
+            <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+              <activeTeam.logo className="size-4" />
+            </div>
+            <div className="grid flex-1 text-start text-sm leading-tight">
+              <span className="truncate font-medium">{activeTeam.name}</span>
+              <span className="truncate text-xs">{activeTeam.plan}</span>
+            </div>
+            <ChevronsUpDown className="ms-auto" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56 rounded-lg"
+            align="start"
+            side={isMobile ? "bottom" : "right"}
+            sideOffset={4}
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuGroupLabel className="text-xs text-muted-foreground">
+                Teams
+              </DropdownMenuGroupLabel>
+              {data.teams.map((team, index) => (
+                <DropdownMenuItem
+                  key={team.name}
+                  onClick={() => setActiveTeam(team)}
+                  className="gap-2 p-2"
+                >
+                  <div className="flex size-6 items-center justify-center rounded-md border">
+                    <team.logo className="size-3.5 shrink-0" />
+                  </div>
+                  {team.name}
+                  <span className="ms-auto text-xs tracking-widest opacity-60">
+                    ⌘{index + 1}
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2 p-2">
+              <div className="flex size-6 items-center justify-center rounded-md border bg-transparent">
+                <Plus className="size-4" />
+              </div>
+              <div className="font-medium text-muted-foreground">Add team</div>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+
+function NavMain({ items }: { items: (typeof data)["navMain"] }) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Platform</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => (
+          <Collapsible
+            key={item.title}
+            defaultOpen={item.isActive}
+            className="group/collapsible"
+          >
+            <SidebarMenuItem>
+              <CollapsibleTrigger
+                render={<SidebarMenuButton tooltip={item.title} />}
+              >
+                {item.icon ? <item.icon /> : null}
+                <span>{item.title}</span>
+                <ChevronRight className="ms-auto transition-transform duration-200 group-data-[open]/collapsible:rotate-90" />
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <SidebarMenuSub>
+                  {item.items.map((subItem) => (
+                    <SidebarMenuSubItem key={subItem}>
+                      <SidebarMenuSubButton
+                        render={<a href="#">{subItem}</a>}
+                      />
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              </CollapsibleContent>
+            </SidebarMenuItem>
+          </Collapsible>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+
+function NavProjects({ projects }: { projects: (typeof data)["projects"] }) {
+  const { isMobile } = useSidebar()
+
+  return (
+    <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+      <SidebarGroupLabel>Projects</SidebarGroupLabel>
+      <SidebarGroupAction>
+        <Plus /> <span className="sr-only">Add Project</span>
+      </SidebarGroupAction>
+      <SidebarMenu>
+        {projects.map((item) => (
+          <SidebarMenuItem key={item.name}>
+            <SidebarMenuButton render={<a href="#" />}>
+              <item.icon />
+              <span>{item.name}</span>
+            </SidebarMenuButton>
+            <DropdownMenu>
+              <DropdownMenuTrigger render={<SidebarMenuAction showOnHover />}>
+                <MoreHorizontal />
+                <span className="sr-only">More</span>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-48 rounded-lg"
+                side={isMobile ? "bottom" : "right"}
+                align={isMobile ? "end" : "start"}
+              >
+                <DropdownMenuItem>
+                  <Folder className="size-4 text-muted-foreground" />
+                  <span>View Project</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <Forward className="size-4 text-muted-foreground" />
+                  <span>Share Project</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive">
+                  <Trash2 className="size-4" />
+                  <span>Delete Project</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        ))}
+        <SidebarMenuItem>
+          <SidebarMenuButton className="text-sidebar-foreground/70">
+            <MoreHorizontal className="text-sidebar-foreground/70" />
+            <span>More</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+
+function NavUser() {
+  const { isMobile } = useSidebar()
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                size="lg"
+                className="data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground"
+              />
+            }
+          >
+            <Avatar className="size-8 rounded-lg">
+              <AvatarImage src={data.user.avatar} alt={data.user.name} />
+              <AvatarFallback className="rounded-lg">PL</AvatarFallback>
+            </Avatar>
+            <div className="grid flex-1 text-start text-sm leading-tight">
+              <span className="truncate font-medium">{data.user.name}</span>
+              <span className="truncate text-xs">{data.user.email}</span>
+            </div>
+            <ChevronsUpDown className="ms-auto size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56 rounded-lg"
+            side={isMobile ? "bottom" : "right"}
+            align="end"
+            sideOffset={4}
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuItem>
+                <CreditCard className="size-4" />
+                Billing
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <Settings2 className="size-4" />
+                Settings
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive">
+              <LogOut className="size-4" />
+              Log out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+
+export function SidebarDemoExample() {
+  return (
+    <div className="relative h-full w-full [transform:translateZ(0)] overflow-hidden">
+      <SidebarProvider className="h-full min-h-0">
+        <Sidebar collapsible="icon" className="h-full">
+          <SidebarHeader>
+            <TeamSwitcher />
+          </SidebarHeader>
+          <SidebarContent>
+            <NavMain items={data.navMain} />
+            <NavProjects projects={data.projects} />
+          </SidebarContent>
+          <SidebarFooter>
+            <NavUser />
+          </SidebarFooter>
+          <SidebarRail />
+        </Sidebar>
+        <SidebarInset>
+          <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+            <SidebarTrigger />
+          </header>
+          <div className="flex flex-1 flex-col items-start justify-center gap-4 p-8">
+            <p className="text-lg font-semibold">
+              A sidebar that collapses to icons.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Click the rail or press ⌘B / Ctrl+B to toggle. Expand a section
+              and scroll the content area — the footer stays pinned.
+            </p>
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </div>
+  )
+}

--- a/apps/web/components/examples/sidebar-rtl.tsx
+++ b/apps/web/components/examples/sidebar-rtl.tsx
@@ -1,0 +1,369 @@
+"use client"
+
+import * as React from "react"
+import {
+  AudioWaveform,
+  Bot,
+  ChevronRight,
+  ChevronsUpDown,
+  CreditCard,
+  Folder,
+  Forward,
+  Frame,
+  GalleryVerticalEnd,
+  LogOut,
+  Map,
+  MoreHorizontal,
+  PieChart,
+  Plus,
+  Settings2,
+  SquareTerminal,
+  Trash2,
+} from "lucide-react"
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@workspace/ui/components/avatar"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@workspace/ui/components/collapsible"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuGroup,
+  DropdownMenuGroupLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+  useSidebar,
+} from "@workspace/ui/components/sidebar"
+
+const data = {
+  user: {
+    name: "taymaz",
+    email: "taymazak1382@gmail.com",
+    avatar: "/avatars/shadcn.jpg",
+  },
+  teams: [
+    { name: "پرشین لبز", logo: GalleryVerticalEnd, plan: "سازمانی" },
+    { name: "شرکت نمونه", logo: AudioWaveform, plan: "استارتاپ" },
+  ],
+  navMain: [
+    {
+      title: "میزکار",
+      icon: SquareTerminal,
+      isActive: true,
+      items: ["تاریخچه", "ستاره‌دار", "تنظیمات"],
+    },
+    {
+      title: "مدل‌ها",
+      icon: Bot,
+      items: ["جنیسیس", "اکسپلورر", "کوانتوم"],
+    },
+    {
+      title: "مستندات",
+      icon: Frame,
+      items: ["مقدمه", "شروع سریع", "آموزش‌ها"],
+    },
+    {
+      title: "تنظیمات",
+      icon: Settings2,
+      items: ["عمومی", "تیم", "صورت‌حساب"],
+    },
+  ],
+  projects: [
+    { name: "مهندسی طراحی", icon: Frame },
+    { name: "فروش و بازاریابی", icon: PieChart },
+    { name: "سفر", icon: Map },
+  ],
+}
+
+function TeamSwitcher() {
+  const { isMobile } = useSidebar()
+  const [activeTeam, setActiveTeam] = React.useState(data.teams[0])
+
+  if (!activeTeam) return null
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                size="lg"
+                className="data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground"
+              />
+            }
+          >
+            <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+              <activeTeam.logo className="size-4" />
+            </div>
+            <div className="grid flex-1 text-start text-sm leading-tight">
+              <span className="truncate font-medium">{activeTeam.name}</span>
+              <span className="truncate text-xs">{activeTeam.plan}</span>
+            </div>
+            <ChevronsUpDown className="ms-auto" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56 rounded-lg"
+            align="start"
+            side={isMobile ? "bottom" : "left"}
+            sideOffset={4}
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuGroupLabel className="text-xs text-muted-foreground">
+                تیم‌ها
+              </DropdownMenuGroupLabel>
+              {data.teams.map((team, index) => (
+                <DropdownMenuItem
+                  key={team.name}
+                  onClick={() => setActiveTeam(team)}
+                  className="gap-2 p-2"
+                >
+                  <div className="flex size-6 items-center justify-center rounded-md border">
+                    <team.logo className="size-3.5 shrink-0" />
+                  </div>
+                  {team.name}
+                  <span className="ms-auto text-xs tracking-widest opacity-60">
+                    ⌘{index + 1}
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2 p-2">
+              <div className="flex size-6 items-center justify-center rounded-md border bg-transparent">
+                <Plus className="size-4" />
+              </div>
+              <div className="font-medium text-muted-foreground">
+                افزودن تیم
+              </div>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+
+function NavMain({ items }: { items: (typeof data)["navMain"] }) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>پلتفرم</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => (
+          <Collapsible
+            key={item.title}
+            defaultOpen={item.isActive}
+            className="group/collapsible"
+          >
+            <SidebarMenuItem>
+              <CollapsibleTrigger
+                render={<SidebarMenuButton tooltip={item.title} />}
+              >
+                {item.icon ? <item.icon /> : null}
+                <span>{item.title}</span>
+                <ChevronRight className="ms-auto transition-transform duration-200 group-data-[open]/collapsible:rotate-90 rtl:-scale-x-100 rtl:group-data-[open]/collapsible:-rotate-90" />
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <SidebarMenuSub>
+                  {item.items.map((subItem) => (
+                    <SidebarMenuSubItem key={subItem}>
+                      <SidebarMenuSubButton
+                        render={<a href="#">{subItem}</a>}
+                      />
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              </CollapsibleContent>
+            </SidebarMenuItem>
+          </Collapsible>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+
+function NavProjects({ projects }: { projects: (typeof data)["projects"] }) {
+  const { isMobile } = useSidebar()
+
+  return (
+    <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+      <SidebarGroupLabel>پروژه‌ها</SidebarGroupLabel>
+      <SidebarGroupAction>
+        <Plus /> <span className="sr-only">افزودن پروژه</span>
+      </SidebarGroupAction>
+      <SidebarMenu>
+        {projects.map((item) => (
+          <SidebarMenuItem key={item.name}>
+            <SidebarMenuButton render={<a href="#" />}>
+              <item.icon />
+              <span>{item.name}</span>
+            </SidebarMenuButton>
+            <DropdownMenu>
+              <DropdownMenuTrigger render={<SidebarMenuAction showOnHover />}>
+                <MoreHorizontal />
+                <span className="sr-only">بیشتر</span>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-48 rounded-lg"
+                side={isMobile ? "bottom" : "left"}
+                align={isMobile ? "end" : "start"}
+              >
+                <DropdownMenuItem>
+                  <Folder className="size-4 text-muted-foreground" />
+                  <span>مشاهده پروژه</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <Forward className="size-4 text-muted-foreground" />
+                  <span>اشتراک‌گذاری پروژه</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive">
+                  <Trash2 className="size-4" />
+                  <span>حذف پروژه</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        ))}
+        <SidebarMenuItem>
+          <SidebarMenuButton className="text-sidebar-foreground/70">
+            <MoreHorizontal className="text-sidebar-foreground/70" />
+            <span>بیشتر</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+
+function NavUser() {
+  const { isMobile } = useSidebar()
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                size="lg"
+                className="data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground"
+              />
+            }
+          >
+            <Avatar className="size-8 rounded-lg">
+              <AvatarImage src={data.user.avatar} alt={data.user.name} />
+              <AvatarFallback className="rounded-lg">PL</AvatarFallback>
+            </Avatar>
+            <div className="grid flex-1 text-start text-sm leading-tight">
+              <span className="truncate font-medium">{data.user.name}</span>
+              <span className="truncate text-xs">{data.user.email}</span>
+            </div>
+            <ChevronsUpDown className="ms-auto size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56 rounded-lg"
+            side={isMobile ? "bottom" : "left"}
+            align="end"
+            sideOffset={4}
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuItem>
+                <CreditCard className="size-4" />
+                صورت‌حساب
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <Settings2 className="size-4" />
+                تنظیمات
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive">
+              <LogOut className="size-4" />
+              خروج از حساب
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+
+export function SidebarRtlExample() {
+  return (
+    <div
+      dir="rtl"
+      className="relative h-full w-full [transform:translateZ(0)] overflow-hidden"
+    >
+      <SidebarProvider className="h-full min-h-0">
+        <Sidebar side="right" dir="rtl" collapsible="icon" className="h-full">
+          <SidebarHeader>
+            <TeamSwitcher />
+          </SidebarHeader>
+          <SidebarContent>
+            <NavMain items={data.navMain} />
+            <NavProjects projects={data.projects} />
+          </SidebarContent>
+          <SidebarFooter>
+            <NavUser />
+          </SidebarFooter>
+          <SidebarRail />
+        </Sidebar>
+        <SidebarInset>
+          <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+            <SidebarTrigger />
+          </header>
+          <div className="flex flex-1 flex-col items-start justify-center gap-4 p-8">
+            <p className="text-lg font-semibold">
+              سایدباری که به آیکن‌ها جمع می‌شود.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              برای باز و بسته کردن روی ریل کلیک کنید یا{" "}
+              <kbd
+                dir="ltr"
+                className="rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px] text-foreground"
+              >
+                ⌘B
+              </kbd>{" "}
+              /{" "}
+              <kbd
+                dir="ltr"
+                className="rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px] text-foreground"
+              >
+                Ctrl+B
+              </kbd>{" "}
+              را بزنید.
+            </p>
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </div>
+  )
+}

--- a/apps/web/components/mdx/component-preview-doc.tsx
+++ b/apps/web/components/mdx/component-preview-doc.tsx
@@ -13,11 +13,14 @@ export async function ComponentPreviewDoc({
   name,
   direction,
   className,
+  kind,
 }: {
   name: string
   /** Locks the preview direction, like the old dir="rtl" prop. */
   direction?: "ltr" | "rtl"
   className?: string
+  /** Blocks/edge-to-edge examples fill the canvas with no padding. */
+  kind?: "component" | "block"
 }) {
   const loader = exampleLoaders[name]
 
@@ -35,6 +38,7 @@ export async function ComponentPreviewDoc({
       // between section headings/prose and the card.
       className={className ?? "mt-4"}
       dir={direction}
+      kind={kind}
       preview={<Example />}
       code={<CodeBlock code={getExampleSource(name)} lang="tsx" />}
     />

--- a/apps/web/components/mdx/components-catalog.tsx
+++ b/apps/web/components/mdx/components-catalog.tsx
@@ -64,6 +64,7 @@ import {
   SelectPreview,
   SeparatorPreview,
   SheetPreview,
+  SidebarPreview,
   SkeletonPreview,
   SliderPreview,
   SpinnerPreview,
@@ -556,6 +557,18 @@ export function ComponentsCatalog() {
       thumbnail: (
         <ThumbnailFrame>
           <SheetPreview />
+        </ThumbnailFrame>
+      ),
+    },
+    {
+      title: "Sidebar",
+      href: "/docs/components/sidebar" as const,
+      description:
+        "A composable, collapsible application sidebar with mobile drawer, tooltips, and RTL support, built on Base UI.",
+      createdAt: "2026-08-22",
+      thumbnail: (
+        <ThumbnailFrame>
+          <SidebarPreview />
         </ThumbnailFrame>
       ),
     },

--- a/apps/web/components/mdx/pre-code.tsx
+++ b/apps/web/components/mdx/pre-code.tsx
@@ -53,3 +53,64 @@ export function PreCode({ children }: { children?: ReactNode }) {
     </div>
   )
 }
+
+/**
+ * rehype-pretty-code wraps fences carrying `title="..."` meta in a
+ * <figure> whose figcaption holds the title. Without this mapper the
+ * title leaks in as bare text above an untitled card, and stacked
+ * titled fences run together with no separation. Mapping figure here
+ * routes the fence through CodeBlock's own title header instead.
+ */
+function findTitle(node: ReactNode): string | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findTitle(child)
+      if (found !== null) return found
+    }
+    return null
+  }
+  if (
+    isValidElement<Record<string, unknown>>(node) &&
+    "data-rehype-pretty-code-title" in node.props
+  ) {
+    return extractText(node)
+  }
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return findTitle(node.props.children)
+  }
+  return null
+}
+
+/** Strips the title-carrying figcaption, leaving the raw pre behind. */
+function withoutTitle(node: ReactNode): ReactNode {
+  if (Array.isArray(node)) {
+    return node.map((child) => withoutTitle(child))
+  }
+  if (
+    isValidElement<Record<string, unknown>>(node) &&
+    "data-rehype-pretty-code-title" in node.props
+  ) {
+    return null
+  }
+  return node
+}
+
+export function PreFigure({ children }: { children?: ReactNode }) {
+  const title = findTitle(children)
+
+  // No pretty-code title: not a titled code fence — render as-is.
+  if (title === null) {
+    return <figure>{children}</figure>
+  }
+
+  const rest = extractText(withoutTitle(children))
+    .replace(/^\n/, "")
+    .replace(/\n$/, "")
+  const lang = extractLanguage(children) ?? "tsx"
+
+  return (
+    <div className="mt-4">
+      <CodeBlock code={rest} lang={lang} title={title} />
+    </div>
+  )
+}

--- a/apps/web/content/docs/components/sidebar.mdx
+++ b/apps/web/content/docs/components/sidebar.mdx
@@ -1,6 +1,225 @@
 ---
 title: "Sidebar"
-description: "Not yet ported to PersianLabs/ui — use shadcn's version."
+description: "A composable, collapsible application sidebar with mobile drawer, tooltips, and RTL support. Built on Base UI."
 ---
 
-Not ported here yet. Visit shadcn's Sidebar docs for the component [ui.shadcn.com/docs/components/base/sidebar](https://ui.shadcn.com/docs/components/base/sidebar).
+A composable, themeable, and customizable sidebar component ported from shadcn/ui's Base UI version, with first-class RTL support.
+
+Sidebars are one of the most complex components to build — they are central to any application and contain a lot of moving parts. This one ships as a single primitive family: `SidebarProvider`, `Sidebar`, and composable header/content/footer/group/menu parts.
+
+<LastEdited path="apps/web/content/docs/components/sidebar.mdx" />
+
+<Credits
+  sources={[{ label: "shadcn/ui", href: "https://ui.shadcn.com" }]}
+  changed
+  changes={[
+    "Baked in RTL support upstream describes as an upgrade path: physical data-[side] positioning selectors for the fixed panel and rail, a dir prop threaded into the desktop container and the mobile Sheet, and rtl:rotate-180 on the SidebarTrigger icon",
+    "Replaced remaining physical classes with logical properties where behavior allows: end-1/end-1.5 for menu actions/badges and border-s for sub-menus (with mirrored translate)",
+    "Uses this repo's Sheet, Tooltip, Button, Input, Separator, Skeleton, useIsMobile (@/hooks/use-media-query), and useControllableState (@/hooks/use-controllable-state) instead of upstream equivalents",
+    "Hides the mobile close button via SheetContent's showCloseButton={false} instead of a [&>button]:hidden override",
+    "SidebarMenuSkeleton derives its random width from React.useId so server and hydration markup match",
+  ]}
+/>
+
+## Overview
+
+<ComponentPreview name="sidebar-demo" kind="block" direction="ltr" />
+
+## Installation
+
+<InstallTabs
+  command="npx shadcn@latest add @persianlabsui/sidebar"
+  packages="@base-ui/react class-variance-authority lucide-react"
+  sourceName="sidebar"
+  sourceTitle="components/ui/sidebar.tsx"
+/>
+
+## Usage
+
+```tsx title="app/layout.tsx"
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar"
+import { AppSidebar } from "@/components/app-sidebar"
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <main>
+        <SidebarTrigger />
+        {children}
+      </main>
+    </SidebarProvider>
+  )
+}
+```
+
+```tsx title="components/app-sidebar.tsx"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarHeader,
+} from "@/components/ui/sidebar"
+
+export function AppSidebar() {
+  return (
+    <Sidebar>
+      <SidebarHeader />
+      <SidebarContent>
+        <SidebarGroup />
+        <SidebarGroup />
+      </SidebarContent>
+      <SidebarFooter />
+    </Sidebar>
+  )
+}
+```
+
+## Composition
+
+Use the following composition to build a `Sidebar` layout:
+
+```text
+SidebarProvider
+├── Sidebar
+│   ├── SidebarHeader
+│   ├── SidebarContent
+│   │   ├── SidebarGroup
+│   │   │   ├── SidebarGroupLabel
+│   │   │   ├── SidebarGroupAction
+│   │   │   ├── SidebarGroupContent
+│   │   │   └── SidebarMenu
+│   │   │       ├── SidebarMenuItem
+│   │   │       │   ├── SidebarMenuButton
+│   │   │       │   ├── SidebarMenuAction
+│   │   │       │   └── SidebarMenuBadge
+│   │   │       └── SidebarMenuItem
+│   │   │           ├── SidebarMenuButton
+│   │   │           └── SidebarMenuSub
+│   │   │               └── SidebarMenuSubItem
+│   │   └── SidebarGroup
+│   ├── SidebarFooter
+│   └── SidebarRail
+├── SidebarInset
+└── SidebarTrigger
+```
+
+## Structure
+
+- **SidebarProvider** — Handles collapsible state, the ⌘B/Ctrl+B shortcut, and provides sidebar context.
+- **Sidebar** — The main collapsible panel; renders as a fixed panel on desktop and a Sheet on mobile.
+- **SidebarHeader** — Sticky at the top; branding, titles, or workspace switchers.
+- **SidebarFooter** — Sticky at the bottom; user menus or settings.
+- **SidebarContent** — Scrollable region between header and footer.
+- **SidebarGroup** — Groups related navigation with optional label, action, and content areas.
+- **SidebarMenu / SidebarMenuItem** — Menu structure for links, badges, actions, and nested submenus.
+- **SidebarRail** — Hover rail on the panel edge that toggles the sidebar.
+- **SidebarInset** — Wraps main content when using the `inset` variant.
+- **SidebarTrigger** — Control that toggles the sidebar open or collapsed.
+
+## Examples
+
+### RTL
+
+Pass `dir="rtl"` together with `side="right"` for Persian layouts. The panel docks to the right, the rail and trigger icon mirror, and collapsed items show tooltips on the correct side via logical `side="inline-end"`.
+
+<ComponentPreview name="sidebar-rtl" direction="rtl" kind="block" />
+
+## SidebarProvider
+
+Provides the sidebar context. Always wrap your application (or layout) in it.
+
+### Width
+
+For a single sidebar, edit the constants in `sidebar.tsx`:
+
+```tsx
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+```
+
+For multiple sidebars, set CSS variables through the provider:
+
+```tsx
+<SidebarProvider
+  style={
+    {
+      "--sidebar-width": "20rem",
+      "--sidebar-width-mobile": "20rem",
+    } as React.CSSProperties
+  }
+>
+  <Sidebar />
+</SidebarProvider>
+```
+
+### Keyboard Shortcut
+
+Toggle with ⌘B (Mac) or Ctrl+B (Windows/Linux). Change the key by editing `SIDEBAR_KEYBOARD_SHORTCUT` in `sidebar.tsx`.
+
+## Sidebar
+
+The main collapsible panel.
+
+| Prop          | Type                               | Description                             |
+| ------------- | ---------------------------------- | --------------------------------------- |
+| `side`        | `left` \| `right`                  | The side of the sidebar.                |
+| `variant`     | `sidebar` \| `floating` \| `inset` | The visual variant of the sidebar.      |
+| `collapsible` | `offcanvas` \| `icon` \| `none`    | Collapse behavior of the sidebar.       |
+| `dir`         | `ltr` \| `rtl`                     | Text direction of the sidebar contents. |
+
+> **Note:** If you use the `inset` variant, wrap your main content in a `SidebarInset` component.
+
+```tsx
+<SidebarProvider>
+  <Sidebar variant="inset" />
+  <SidebarInset>
+    <main>{children}</main>
+  </SidebarInset>
+</SidebarProvider>
+```
+
+## useSidebar
+
+Controls the sidebar from anywhere inside `SidebarProvider`.
+
+```tsx
+import { useSidebar } from "@/components/ui/sidebar"
+
+export function CustomTrigger() {
+  const { toggleSidebar } = useSidebar()
+
+  return <button onClick={toggleSidebar}>Toggle Sidebar</button>
+}
+```
+
+## Styling
+
+Style based on sidebar state with data attributes:
+
+```tsx
+<Sidebar collapsible="icon">
+  <SidebarContent>
+    {/* Hide an element when collapsed to icons */}
+    <SidebarGroup className="group-data-[collapsible=icon]:hidden" />
+  </SidebarContent>
+</Sidebar>
+```
+
+## API Reference
+
+import {
+  sidebarApi,
+  sidebarMenuButtonApi,
+  sidebarProviderApi,
+  useSidebarApi,
+} from "@/lib/api-data/sidebar"
+
+<ApiReference title="SidebarProvider" rows={sidebarProviderApi} />
+
+<ApiReference title="Sidebar" rows={sidebarApi} />
+
+<ApiReference title="useSidebar" rows={useSidebarApi} />
+
+<ApiReference title="SidebarMenuButton" rows={sidebarMenuButtonApi} />

--- a/apps/web/lib/api-data/sidebar.ts
+++ b/apps/web/lib/api-data/sidebar.ts
@@ -1,0 +1,143 @@
+import type { ApiReferenceRow } from "@/components/api-reference"
+
+export const sidebarProviderApi: ApiReferenceRow[] = [
+  {
+    prop: "defaultOpen",
+    type: "boolean",
+    default: "true",
+    description: "Whether the sidebar is initially expanded when uncontrolled.",
+  },
+  {
+    prop: "open",
+    type: "boolean",
+    default: "undefined",
+    description: "The controlled expanded state of the sidebar.",
+  },
+  {
+    prop: "onOpenChange",
+    type: "(open: boolean) => void",
+    default: "-",
+    description: "Called when the expanded state changes.",
+  },
+  {
+    prop: "style",
+    type: "React.CSSProperties",
+    default: "-",
+    description:
+      "Style for the wrapper. Set --sidebar-width or --sidebar-width-icon here to override the defaults.",
+  },
+]
+
+export const sidebarApi: ApiReferenceRow[] = [
+  {
+    prop: "side",
+    type: '"left" | "right"',
+    default: '"left"',
+    description:
+      "Which physical edge the sidebar docks to. The panel and its rail follow this side in both directions.",
+  },
+  {
+    prop: "variant",
+    type: '"sidebar" | "floating" | "inset"',
+    default: '"sidebar"',
+    description:
+      "Visual treatment. floating adds a border, radius, and padding; inset pairs with SidebarInset. With inset, wrap main content in SidebarInset.",
+  },
+  {
+    prop: "collapsible",
+    type: '"offcanvas" | "icon" | "none"',
+    default: '"offcanvas"',
+    description:
+      "Collapse behavior. offcanvas slides out of view, icon collapses to an icon rail, none keeps it always visible (uncontrollable).",
+  },
+  {
+    prop: "dir",
+    type: '"ltr" | "rtl"',
+    default: '"ltr"',
+    description:
+      'Text direction for the sidebar contents and its mobile sheet. Pass rtl together with side="right" for Persian layouts.',
+  },
+]
+
+export const useSidebarApi: ApiReferenceRow[] = [
+  {
+    prop: "state",
+    type: '"expanded" | "collapsed"',
+    default: "-",
+    description: "Derived open state of the desktop sidebar.",
+  },
+  {
+    prop: "open",
+    type: "boolean",
+    default: "-",
+    description: "Whether the desktop sidebar is open.",
+  },
+  {
+    prop: "setOpen",
+    type: "(open: boolean) => void",
+    default: "-",
+    description: "Sets the desktop sidebar state.",
+  },
+  {
+    prop: "openMobile",
+    type: "boolean",
+    default: "-",
+    description: "Whether the mobile sheet sidebar is open.",
+  },
+  {
+    prop: "setOpenMobile",
+    type: "(open: boolean) => void",
+    default: "-",
+    description: "Sets the mobile sheet state.",
+  },
+  {
+    prop: "isMobile",
+    type: "boolean",
+    default: "-",
+    description:
+      "Whether the viewport is below md. Drives which sidebar variant renders.",
+  },
+  {
+    prop: "toggleSidebar",
+    type: "() => void",
+    default: "-",
+    description:
+      "Toggles the sidebar on either surface. Also bound to ⌘B / Ctrl+B by SidebarProvider.",
+  },
+]
+
+export const sidebarMenuButtonApi: ApiReferenceRow[] = [
+  {
+    prop: "render",
+    type: "ReactElement | ((props) => ReactElement)",
+    default: "-",
+    description:
+      "Base UI render prop. Render a link (e.g. <a> or router Link) instead of a button while keeping menu styles.",
+  },
+  {
+    prop: "isActive",
+    type: "boolean",
+    default: "false",
+    description: "Marks the item active with accent background and text.",
+  },
+  {
+    prop: "variant",
+    type: '"default" | "outline"',
+    default: '"default"',
+    description: "Visual style of the button.",
+  },
+  {
+    prop: "size",
+    type: '"default" | "sm" | "lg"',
+    default: '"default"',
+    description:
+      "Height of the button. lg renders icon-only content suitable for large collapsed rows.",
+  },
+  {
+    prop: "tooltip",
+    type: "string | TooltipContentProps",
+    default: "-",
+    description:
+      "Tooltip shown on the inline-end side when the sidebar is collapsed to icons.",
+  },
+]

--- a/apps/web/lib/component-opengraph-previews.tsx
+++ b/apps/web/lib/component-opengraph-previews.tsx
@@ -1310,6 +1310,123 @@ export function SheetPreview() {
   )
 }
 
+export function SidebarPreview() {
+  const rows = [
+    { width: "70%", active: true },
+    { width: "55%", active: false },
+    { width: "62%", active: false },
+  ]
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "330px",
+        height: "210px",
+        borderRadius: "15px",
+        border: "2px solid rgba(242,240,238,0.18)",
+        backgroundColor: "rgba(242,240,238,0.06)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+          width: "38%",
+          padding: "18px 14px",
+          backgroundColor: "#1a1a1a",
+          borderInlineEnd: "2px solid rgba(242,240,238,0.16)",
+        }}
+      >
+        {rows.map((row) => (
+          <div
+            key={row.width}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              width: row.width,
+              height: "22px",
+              borderRadius: "8px",
+              backgroundColor: row.active
+                ? "rgba(242,240,238,0.9)"
+                : "rgba(242,240,238,0.08)",
+            }}
+          >
+            <div
+              style={{
+                width: "8px",
+                height: "8px",
+                borderRadius: "999px",
+                marginLeft:'4px',
+                backgroundColor: row.active
+                  ? "#1a1a1a"
+                  : "rgba(242,240,238,0.5)",
+              }}
+            />
+          </div>
+        ))}
+      </div>
+      <div
+        style={{
+          flex: 1,
+          padding: "20px",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            marginBottom: "14px",
+          }}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="rgba(242,240,238,0.9)"
+            strokeWidth={2.5}
+            strokeLinecap="round"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+            <line x1="9" y1="3" x2="9" y2="21" />
+          </svg>
+          <div
+            style={{
+              width: "34%",
+              height: "8px",
+              borderRadius: "999px",
+              backgroundColor: "rgba(242,240,238,0.4)",
+            }}
+          />
+        </div>
+        <div
+          style={{
+            width: "82%",
+            height: "9px",
+            borderRadius: "999px",
+            backgroundColor: "rgba(242,240,238,0.25)",
+            marginBottom: "9px",
+          }}
+        />
+        <div
+          style={{
+            width: "58%",
+            height: "9px",
+            borderRadius: "999px",
+            backgroundColor: "rgba(242,240,238,0.25)",
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
 export function ContextMenuPreview() {
   const rows = ["Back", "Forward", "Reload"]
   return (

--- a/apps/web/lib/component-previews.tsx
+++ b/apps/web/lib/component-previews.tsx
@@ -1322,6 +1322,109 @@ export function SheetPreview() {
   )
 }
 
+export function SidebarPreview() {
+  const rows = [
+    { width: "70%", active: true },
+    { width: "55%", active: false },
+    { width: "62%", active: false },
+  ]
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "220px",
+        height: "140px",
+        borderRadius: "10px",
+        backgroundColor: preview.background,
+        border: `1px solid ${preview.border}`,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "8px",
+          width: "38%",
+          padding: "12px 8px",
+          backgroundColor: preview.muted,
+          borderInlineEnd: `1px solid ${preview.border}`,
+        }}
+      >
+        {rows.map((row) => (
+          <div
+            key={row.width}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              width: row.width,
+              height: "16px",
+              borderRadius: "6px",
+              backgroundColor: row.active ? preview.primary : preview.muted,
+            }}
+          >
+            <div
+              style={{
+                width: "6px",
+                height: "6px",
+                borderRadius: "999px",
+                marginInlineStart: "5px",
+                backgroundColor: row.active
+                  ? preview.primaryForeground
+                  : preview.mutedForeground,
+              }}
+            />
+          </div>
+        ))}
+      </div>
+      <div style={{ flex: 1, padding: "14px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "6px",
+            marginBottom: "10px",
+          }}
+        >
+          <div
+            style={{
+              width: "12px",
+              height: "2px",
+              backgroundColor: preview.foreground,
+            }}
+          />
+          <div
+            style={{
+              width: "30%",
+              height: "5px",
+              borderRadius: "999px",
+              backgroundColor: preview.muted,
+            }}
+          />
+        </div>
+        <div
+          style={{
+            width: "80%",
+            height: "6px",
+            borderRadius: "999px",
+            backgroundColor: preview.muted,
+            marginBottom: "6px",
+          }}
+        />
+        <div
+          style={{
+            width: "55%",
+            height: "6px",
+            borderRadius: "999px",
+            backgroundColor: preview.muted,
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
 export function ContextMenuPreview() {
   const rows = ["Back", "Forward", "Reload"]
   return (

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -23,7 +23,7 @@ import { DocLastEdited } from "@/components/mdx/doc-last-edited"
 import { ComponentsCatalog } from "@/components/mdx/components-catalog"
 import { DocExampleSection } from "@/components/mdx/example-section"
 import { InstallTabs } from "@/components/mdx/install-tabs"
-import { PreCode } from "@/components/mdx/pre-code"
+import { PreCode, PreFigure } from "@/components/mdx/pre-code"
 import { ThemePreview, ThemeVariablesCode } from "@/components/mdx/theme-doc"
 
 /**
@@ -153,6 +153,7 @@ export const mdxComponents = {
       />
     )
   },
+  figure: PreFigure,
   pre: PreCode,
   table: ({ children, ...props }: React.ComponentProps<"table">) => (
     <div className="mt-4 overflow-hidden rounded-lg border border-border">

--- a/apps/web/registry.json
+++ b/apps/web/registry.json
@@ -536,6 +536,32 @@
       ]
     },
     {
+      "name": "sidebar",
+      "type": "registry:ui",
+      "title": "Sidebar",
+      "description": "A composable, collapsible application sidebar with mobile drawer, tooltips, and RTL support, built on Base UI.",
+      "registryDependencies": [
+        "utils",
+        "@persianlabsui/button",
+        "@persianlabsui/input",
+        "@persianlabsui/separator",
+        "@persianlabsui/sheet",
+        "@persianlabsui/skeleton",
+        "@persianlabsui/tooltip"
+      ],
+      "dependencies": [
+        "@base-ui/react",
+        "class-variance-authority",
+        "lucide-react"
+      ],
+      "files": [
+        {
+          "path": "registry/base/ui/sidebar.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "carousel",
       "type": "registry:ui",
       "title": "Carousel",

--- a/apps/web/registry/base/ui/sidebar.tsx
+++ b/apps/web/registry/base/ui/sidebar.tsx
@@ -1,0 +1,727 @@
+"use client"
+
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva } from "class-variance-authority"
+import { PanelLeftIcon } from "lucide-react"
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useControllableState } from "@/hooks/use-controllable-state"
+import { useIsMobile } from "@/hooks/use-media-query"
+import { cn } from "@/lib/utils"
+
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: onOpenChangeProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen,
+    onChange: onOpenChangeProp,
+  })
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  const toggleSidebar = React.useCallback(() => {
+    if (isMobile) setOpenMobile((open) => !open)
+    else setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  React.useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  return (
+    <SidebarContext.Provider
+      value={{
+        state: open ? "expanded" : "collapsed",
+        open,
+        setOpen,
+        isMobile,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+      }}
+    >
+      <TooltipProvider delay={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  style,
+  children,
+  dir = "ltr",
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        data-sidebar="sidebar"
+        data-variant={variant}
+        dir={dir}
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className
+        )}
+        style={style}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          side={side}
+          showCloseButton={false}
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+              ...style,
+            } as React.CSSProperties
+          }
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      data-slot="sidebar"
+      data-sidebar="sidebar"
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+    >
+      {/* Gap ghost on the layout flow so main content reserves the panel's
+          width while the real panel below is fixed-positioned. */}
+      <div
+        data-slot="sidebar-gap"
+        className="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[collapsible=offcanvas]:w-0 group-data-[side=right]:rotate-180"
+      />
+      {/* Physical `data-[side]` selectors (not logical properties) position
+          the fixed panel -- offcanvas slides it fully outside the viewport
+          edge, which inset/border math can't express direction-agnostically. */}
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          variant === "floating" && "rounded-lg border shadow-sm",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar-inner"
+          data-slot="sidebar-inner"
+          dir={dir}
+          className={cn(
+            "flex h-full w-full flex-col",
+            variant === "floating" &&
+              "overflow-hidden rounded-lg bg-sidebar text-sidebar-foreground",
+            variant === "inset" && "bg-sidebar text-sidebar-foreground"
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon className="rtl:rotate-180" />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:cursor-col-resize hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        className
+      )}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn("flex min-h-0 flex-1 flex-col gap-2", className)}
+      {...props}
+    >
+      {/* min-h-0 lets the ScrollArea root shrink below its content size --
+          without it the expanded menus overflow over the footer instead of
+          scrolling. */}
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="flex w-full flex-col gap-2">{children}</div>
+      </ScrollArea>
+    </div>
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-group-label", sidebar: "group-label" },
+  })
+}
+
+function SidebarGroupAction({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute end-2 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          "group-data-[collapsible=icon]:hidden",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-group-action", sidebar: "group-action" },
+  })
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-start text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span:last-child]:truncate",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button"> & {
+  isActive?: boolean
+  variant?: "default" | "outline"
+  size?: "default" | "sm" | "lg"
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+}) {
+  const { isMobile, state } = useSidebar()
+
+  const commonProps = {
+    "data-sidebar": "menu-button",
+    "data-size": size,
+    "data-active": isActive,
+    className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+  } as React.ComponentPropsWithoutRef<"button">
+
+  const button = useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(commonProps, props),
+    render,
+    state: { slot: "sidebar-menu-button" },
+  })
+
+  if (!tooltip) {
+    return button
+  }
+
+  const tooltipProps =
+    typeof tooltip === "string" ? { children: tooltip } : tooltip
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipContent
+        side="inline-end"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltipProps}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  showOnHover = false,
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button"> & {
+  showOnHover?: boolean
+}) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute end-1 top-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          "group-data-[collapsible=icon]:hidden peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1",
+          showOnHover &&
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-menu-action", sidebar: "menu-action" },
+  })
+}
+
+function SidebarMenuBadge({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "pointer-events-none absolute end-1.5 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
+          "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1",
+          "outline-hidden peer-focus-visible/menu-button:ring-2 peer-focus-visible/menu-button:ring-sidebar-ring",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-menu-badge", sidebar: "menu-badge" },
+  })
+}
+
+function SidebarMenuSkeleton({
+  showIcon = false,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Width is derived from useId rather than Math.random() so server and
+  // hydration markup match; useId is stable across both.
+  const id = React.useId()
+  const width = `${50 + (Math.abs(hashString(id)) % 40)}%`
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          data-slot="sidebar-menu-skeleton-icon"
+          data-sidebar="menu-skeleton-icon"
+          className="size-4 rounded-md"
+        />
+      )}
+      <Skeleton
+        data-slot="sidebar-menu-skeleton-text"
+        data-sidebar="menu-skeleton-text"
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        style={{ "--skeleton-width": width } as React.CSSProperties}
+      />
+    </div>
+  )
+}
+
+function hashString(value: string): number {
+  let hash = 0
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i)
+    hash |= 0
+  }
+  return hash
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-s border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden ltr:translate-x-px rtl:-translate-x-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  size = "md",
+  isActive = false,
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a"> & {
+  size?: "sm" | "md"
+  isActive?: boolean
+}) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        "data-sidebar": "menu-sub-button",
+        "data-size": size,
+        "data-active": isActive,
+        className: cn(
+          "flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-2 py-1 text-start text-xs text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&>span:last-child]:truncate",
+          size === "sm" && "text-xs",
+          size === "md" && "text-sm",
+          "group-data-[collapsible=icon]:hidden",
+          className
+        ),
+      } as React.ComponentPropsWithoutRef<"a">,
+      props
+    ),
+    render,
+    state: { slot: "sidebar-menu-sub-button" },
+  })
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/apps/web/registry/base/ui/tooltip.tsx
+++ b/apps/web/registry/base/ui/tooltip.tsx
@@ -85,13 +85,16 @@ function TooltipContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
+  showArrow = true,
   children,
   ...props
 }: TooltipPrimitive.Popup.Props &
   Pick<
     TooltipPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & {
+    showArrow?: boolean
+  }) {
   const { dir } = React.useContext(TooltipDirContext)
 
   return (
@@ -113,7 +116,9 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          {showArrow && (
+            <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5 rtl:data-[side=inline-end]:-right-1 rtl:data-[side=inline-end]:left-auto rtl:data-[side=inline-start]:right-auto rtl:data-[side=inline-start]:-left-1" />
+          )}
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -1,0 +1,727 @@
+"use client"
+
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva } from "class-variance-authority"
+import { PanelLeftIcon } from "lucide-react"
+import * as React from "react"
+
+import { Button } from "@workspace/ui/components/button"
+import { Input } from "@workspace/ui/components/input"
+import { ScrollArea } from "@workspace/ui/components/scroll-area"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@workspace/ui/components/sheet"
+import { Separator } from "@workspace/ui/components/separator"
+import { Skeleton } from "@workspace/ui/components/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@workspace/ui/components/tooltip"
+import { useControllableState } from "@workspace/ui/hooks/use-controllable-state"
+import { useIsMobile } from "@workspace/ui/hooks/use-media-query"
+import { cn } from "@workspace/ui/lib/utils"
+
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: onOpenChangeProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen,
+    onChange: onOpenChangeProp,
+  })
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  const toggleSidebar = React.useCallback(() => {
+    if (isMobile) setOpenMobile((open) => !open)
+    else setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  React.useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  return (
+    <SidebarContext.Provider
+      value={{
+        state: open ? "expanded" : "collapsed",
+        open,
+        setOpen,
+        isMobile,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+      }}
+    >
+      <TooltipProvider delay={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  style,
+  children,
+  dir = "ltr",
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        data-sidebar="sidebar"
+        data-variant={variant}
+        dir={dir}
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className
+        )}
+        style={style}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          side={side}
+          showCloseButton={false}
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+              ...style,
+            } as React.CSSProperties
+          }
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      data-slot="sidebar"
+      data-sidebar="sidebar"
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+    >
+      {/* Gap ghost on the layout flow so main content reserves the panel's
+          width while the real panel below is fixed-positioned. */}
+      <div
+        data-slot="sidebar-gap"
+        className="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[collapsible=offcanvas]:w-0 group-data-[side=right]:rotate-180"
+      />
+      {/* Physical `data-[side]` selectors (not logical properties) position
+          the fixed panel -- offcanvas slides it fully outside the viewport
+          edge, which inset/border math can't express direction-agnostically. */}
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          variant === "floating" && "rounded-lg border shadow-sm",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar-inner"
+          data-slot="sidebar-inner"
+          dir={dir}
+          className={cn(
+            "flex h-full w-full flex-col",
+            variant === "floating" &&
+              "overflow-hidden rounded-lg bg-sidebar text-sidebar-foreground",
+            variant === "inset" && "bg-sidebar text-sidebar-foreground"
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon className="rtl:rotate-180" />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:cursor-col-resize hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        className
+      )}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn("flex min-h-0 flex-1 flex-col gap-2", className)}
+      {...props}
+    >
+      {/* min-h-0 lets the ScrollArea root shrink below its content size --
+          without it the expanded menus overflow over the footer instead of
+          scrolling. */}
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="flex w-full flex-col gap-2">{children}</div>
+      </ScrollArea>
+    </div>
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-group-label", sidebar: "group-label" },
+  })
+}
+
+function SidebarGroupAction({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute end-2 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          "group-data-[collapsible=icon]:hidden",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-group-action", sidebar: "group-action" },
+  })
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-start text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span:last-child]:truncate",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button"> & {
+  isActive?: boolean
+  variant?: "default" | "outline"
+  size?: "default" | "sm" | "lg"
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+}) {
+  const { isMobile, state } = useSidebar()
+
+  const commonProps = {
+    "data-sidebar": "menu-button",
+    "data-size": size,
+    "data-active": isActive,
+    className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+  } as React.ComponentPropsWithoutRef<"button">
+
+  const button = useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(commonProps, props),
+    render,
+    state: { slot: "sidebar-menu-button" },
+  })
+
+  if (!tooltip) {
+    return button
+  }
+
+  const tooltipProps =
+    typeof tooltip === "string" ? { children: tooltip } : tooltip
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipContent
+        side="inline-end"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltipProps}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  showOnHover = false,
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button"> & {
+  showOnHover?: boolean
+}) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute end-1 top-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          "group-data-[collapsible=icon]:hidden peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1",
+          showOnHover &&
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-menu-action", sidebar: "menu-action" },
+  })
+}
+
+function SidebarMenuBadge({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "pointer-events-none absolute end-1.5 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
+          "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1",
+          "outline-hidden peer-focus-visible/menu-button:ring-2 peer-focus-visible/menu-button:ring-sidebar-ring",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: { slot: "sidebar-menu-badge", sidebar: "menu-badge" },
+  })
+}
+
+function SidebarMenuSkeleton({
+  showIcon = false,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Width is derived from useId rather than Math.random() so server and
+  // hydration markup match; useId is stable across both.
+  const id = React.useId()
+  const width = `${50 + (Math.abs(hashString(id)) % 40)}%`
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          data-slot="sidebar-menu-skeleton-icon"
+          data-sidebar="menu-skeleton-icon"
+          className="size-4 rounded-md"
+        />
+      )}
+      <Skeleton
+        data-slot="sidebar-menu-skeleton-text"
+        data-sidebar="menu-skeleton-text"
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        style={{ "--skeleton-width": width } as React.CSSProperties}
+      />
+    </div>
+  )
+}
+
+function hashString(value: string): number {
+  let hash = 0
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i)
+    hash |= 0
+  }
+  return hash
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-s border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden ltr:translate-x-px rtl:-translate-x-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  size = "md",
+  isActive = false,
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a"> & {
+  size?: "sm" | "md"
+  isActive?: boolean
+}) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        "data-sidebar": "menu-sub-button",
+        "data-size": size,
+        "data-active": isActive,
+        className: cn(
+          "flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-2 py-1 text-start text-xs text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&>span:last-child]:truncate",
+          size === "sm" && "text-xs",
+          size === "md" && "text-sm",
+          "group-data-[collapsible=icon]:hidden",
+          className
+        ),
+      } as React.ComponentPropsWithoutRef<"a">,
+      props
+    ),
+    render,
+    state: { slot: "sidebar-menu-sub-button" },
+  })
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -117,7 +117,7 @@ function TooltipContent({
         >
           {children}
           {showArrow && (
-            <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+            <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5 rtl:data-[side=inline-end]:-right-1 rtl:data-[side=inline-end]:left-auto rtl:data-[side=inline-start]:right-auto rtl:data-[side=inline-start]:-left-1" />
           )}
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>


### PR DESCRIPTION
## Summary

Ports shadcn/ui's Base UI sidebar to the registry with first-class RTL support.

**Component** (`packages/ui/src/components/sidebar.tsx` + registry mirror, registered in `registry.json`)

- Full primitive family: Provider/Sidebar/Trigger/Rail/Inset/Header/Footer/Content/Group(+Label/Action/Content)/Menu(+Item/Button/Action/Badge/Sub/SubButton/Skeleton) and `useSidebar`
- Baked-in RTL: physical `data-[side]` positioning for the fixed panel and rail, `dir` prop threaded into the desktop container and mobile Sheet, `rtl:rotate-180` trigger icon; rail uses `hover:cursor-col-resize`
- `SidebarContent` scrolls via the repo's ScrollArea (`scroll-fade-y`) — root gets `min-h-0` so expanded sections scroll instead of overflowing over the footer
- Collapsed group labels collapse their slot via upstream's `-mt-8`; skeleton widths derive from `useId` (SSR-safe); polymorphic parts use Base UI `useRender`

**Tooltip**: arrow now lands on the correct edge for `inline-start/end` in RTL (Base UI leaves `data-side` unresolved).

**Docs site**

- New `/docs/components/sidebar` page (replacing the "not yet ported" stub): Overview preview, Usage with titled fences, composition tree, provider/sidebar/useSidebar/menu-button API reference tables
- Two examples with identical structure — LTR English demo and a fully-Persian RTL translation (`side="right"`, mirrored chevron, Persian dropdowns)
- Gallery thumbnail, components-catalog entry, OG image route

**Preview island improvements** (used by all docs pages)

- Direction switch + expand controls moved into a toolbar row above the canvas
- New `kind="block"` pass-through for edge-to-edge previews; block canvas has a definite in-card height and stretches children fullscreen (`h-full` → viewport-filling on /preview routes)
- Page spacing class no longer leaks into the fixed fullscreen layer
- Fullscreen bottom dock is pointer-events-none except the control pill itself

**Docs pipeline**

- Fences carrying `title="..."` render through CodeBlock's title header (new `figure:` mapper) instead of leaking a bare figcaption

## Verification

- typecheck/lint green in packages/ui and apps/web; 98 unit tests pass
- OG route returns 200 image/png; guard script resolves all example names
