### PR TITLE
fix(registry): ship utils item so cn resolves on fresh installs

### DIFF
--- a/apps/web/public/r/registry.json
+++ b/apps/web/public/r/registry.json
@@ -935,6 +935,20 @@
       ]
     },
     {
+      "name": "utils",
+      "type": "registry:lib",
+      "title": "Utils",
+      "description": "The cn() class-merging helper built on clsx and tailwind-merge.",
+      "registryDependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
+      "files": [
+        {
+          "path": "registry/base/lib/utils.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
       "name": "iranian-bank",
       "type": "registry:lib",
       "title": "Iranian Bank",

--- a/apps/web/public/r/utils.json
+++ b/apps/web/public/r/utils.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "utils",
+  "title": "Utils",
+  "description": "The cn() class-merging helper built on clsx and tailwind-merge.",
+  "dependencies": [
+    "clsx",
+    "tailwind-merge"
+  ],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "registry/base/lib/utils.ts",
+      "content": "import { clsx, type ClassValue } from \"clsx\"\nimport { twMerge } from \"tailwind-merge\"\n\nexport function cn(...inputs: ClassValue[]) {\n  return twMerge(clsx(inputs))\n}\n",
+      "type": "registry:lib"
+    }
+  ],
+  "type": "registry:lib"
+}

--- a/apps/web/registry.json
+++ b/apps/web/registry.json
@@ -935,6 +935,20 @@
       ]
     },
     {
+      "name": "utils",
+      "type": "registry:lib",
+      "title": "Utils",
+      "description": "The cn() class-merging helper built on clsx and tailwind-merge.",
+      "registryDependencies": [],
+      "dependencies": ["clsx", "tailwind-merge"],
+      "files": [
+        {
+          "path": "registry/base/lib/utils.ts",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
       "name": "iranian-bank",
       "type": "registry:lib",
       "title": "Iranian Bank",

--- a/apps/web/registry/base/lib/utils.ts
+++ b/apps/web/registry/base/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## What

Implements plans/005-utils-registry-item.md.

78 registry entries declare `"utils"` in `registryDependencies` and every component imports `import { cn } from "@/lib/utils"` — but no `utils` item existed, so fresh consumer installs couldn't resolve it. This adds:

- `apps/web/registry/base/lib/utils.ts` — byte-identical to the internal `packages/ui/src/lib/utils.ts`
- One `registry:lib` manifest entry (modeled on the existing `normalize-persian-digits` item shape)
- Regenerated artifacts: `public/r/utils.json` + updated index

All 78 existing references left untouched — they now resolve. Installable via `npx shadcn add @persianlabsui/utils`.

## Verification

- Manifest parses; exactly one `utils` item; diff purely additive (+14 lines)
- Artifact contains the `cn` source + both dependencies
- `bun run lint && bun run typecheck && bun run build` all green
