### PR TITLE
test(lib): characterize national-id, mobile, postal-code, slug, digit normalizers

### DIFF
--- a/packages/ui/src/lib/iranian-mobile.test.ts
+++ b/packages/ui/src/lib/iranian-mobile.test.ts
@@ -29,9 +29,7 @@ describe("normalizeIranPhone", () => {
   it("falls back to cleaned numeric digits when shaping is impossible", () => {
     expect(normalizeIranPhone("12345")).toBe("12345")
     expect(normalizeIranPhone("abc")).toBe("")
-    expect(normalizeIranPhone("call 0912-123-4567 now")).toBe(
-      "09121234567"
-    )
+    expect(normalizeIranPhone("call 0912-123-4567 now")).toBe("09121234567")
   })
 
   it.each([null, undefined])("returns an empty string for %p", (input) => {

--- a/packages/ui/src/lib/iranian-mobile.test.ts
+++ b/packages/ui/src/lib/iranian-mobile.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isValidIranPhone,
+  maskIranPhone,
+  normalizeIranPhone,
+} from "./iranian-mobile.js"
+
+describe("normalizeIranPhone", () => {
+  it("keeps an already-normalized local number unchanged", () => {
+    expect(normalizeIranPhone("09121234567")).toBe("09121234567")
+  })
+
+  it.each([
+    ["+989121234567"],
+    ["00989121234567"],
+    ["989121234567"],
+    ["9121234567"],
+    ["0912 123 4567"],
+    ["0912-123-4567"],
+    ["0912.123.4567"],
+    ["(+98) 912 1234567"],
+    ["۰۹۱۲۱۲۳۴۵۶۷"],
+    ["٠٩١٢١٢٣٤٥٦٧"],
+  ])("normalizes %s to 09121234567", (raw) => {
+    expect(normalizeIranPhone(raw)).toBe("09121234567")
+  })
+
+  it("falls back to cleaned numeric digits when shaping is impossible", () => {
+    expect(normalizeIranPhone("12345")).toBe("12345")
+    expect(normalizeIranPhone("abc")).toBe("")
+    expect(normalizeIranPhone("call 0912-123-4567 now")).toBe(
+      "09121234567"
+    )
+  })
+
+  it.each([null, undefined])("returns an empty string for %p", (input) => {
+    // @ts-expect-error characterization of runtime null/undefined handling
+    expect(normalizeIranPhone(input)).toBe("")
+  })
+})
+
+describe("isValidIranPhone", () => {
+  it("accepts every claimed format via round-trip through the normalizer", () => {
+    const rawVariants = [
+      "09121234567",
+      "+989121234567",
+      "00989121234567",
+      "989121234567",
+      "9121234567",
+      "0912 123 4567",
+      "۰۹۱۲۱۲۳۴۵۶۷",
+    ]
+    for (const raw of rawVariants) {
+      const normalized = normalizeIranPhone(raw)
+      expect(isValidIranPhone(normalized)).toBe(true)
+      expect(isValidIranPhone(raw)).toBe(true)
+    }
+  })
+
+  it("rejects wrong operator prefixes", () => {
+    expect(isValidIranPhone("08121234567")).toBe(false)
+    expect(isValidIranPhone("+988121234567")).toBe(false)
+  })
+
+  it("rejects numbers that are too short or too long", () => {
+    expect(isValidIranPhone("09121234")).toBe(false)
+    expect(isValidIranPhone("091212345678901")).toBe(false)
+  })
+
+  it.each([null, undefined, "", "not a phone"])("rejects %p", (input) => {
+    // @ts-expect-error characterization of runtime null/undefined handling
+    expect(isValidIranPhone(input)).toBe(false)
+  })
+})
+
+describe("maskIranPhone", () => {
+  it("shows the first 3 and last 4 digits of a normalized number", () => {
+    expect(maskIranPhone("09121234567")).toBe("091***4567")
+  })
+
+  it("masks any accepted format by normalizing first", () => {
+    expect(maskIranPhone("+989121234567")).toBe("091***4567")
+  })
+
+  it("falls back to the raw value when normalization yields nothing", () => {
+    expect(maskIranPhone(null)).toBe("")
+    expect(maskIranPhone("")).toBe("")
+    // @ts-expect-error characterization of runtime null/undefined handling
+    expect(maskIranPhone(undefined)).toBe("")
+  })
+
+  it("masks partial digit runs using the generic first-3/last-4 shape", () => {
+    expect(maskIranPhone("12345")).toBe("123***2345")
+  })
+})

--- a/packages/ui/src/lib/national-id.test.ts
+++ b/packages/ui/src/lib/national-id.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest"
+
+import { isValidNationalId } from "./national-id.js"
+
+/** Prefixes confirmed present in VALID_NATIONAL_ID_PREFIXES. */
+const PRESENT_PREFIXES = ["001", "002", "003", "049"]
+
+/**
+ * Deterministically generates a checksum-valid national ID from an index:
+ * fixed prefix + six nonzero body digits derived from `i`, then appends the
+ * weighted-mod-11 check digit (r < 2 ? r : 11 - r).
+ */
+function generateValidId(i: number): { id: string; remainder: number } {
+  const prefix = PRESENT_PREFIXES[i % PRESENT_PREFIXES.length]
+  const bodyDigits = [7, 3, 5, 11, 13, 17].map(
+    (factor, position) => ((i * factor + position) % 9) + 1
+  )
+  const nineDigits = (prefix + bodyDigits.join("")).slice(0, 9)
+  const sum = nineDigits
+    .split("")
+    .reduce((total, digit, index) => total + Number(digit) * (10 - index), 0)
+  const remainder = sum % 11
+  const check = remainder < 2 ? remainder : 11 - remainder
+  return { id: nineDigits + String(check), remainder }
+}
+
+describe("isValidNationalId", () => {
+  // JSDoc fixtures, ported verbatim
+  it('accepts "0499370899"', () => {
+    expect(isValidNationalId("0499370899")).toBe(true)
+  })
+
+  it('zero-pads "499370899" to a valid ID', () => {
+    expect(isValidNationalId("499370899")).toBe(true)
+  })
+
+  it('normalizes Persian digits before validating "۰۴۹۹۳۷۰۸۹۹"', () => {
+    expect(isValidNationalId("۰۴۹۹۳۷۰۸۹۹")).toBe(true)
+  })
+
+  it('rejects all-zero "0000000000"', () => {
+    expect(isValidNationalId("0000000000")).toBe(false)
+  })
+
+  it('rejects repeated digits "1111111111"', () => {
+    expect(isValidNationalId("1111111111")).toBe(false)
+  })
+
+  it('rejects bad checksum "0499370898"', () => {
+    expect(isValidNationalId("0499370898")).toBe(false)
+  })
+
+  it("rejects fewer than 8 digits", () => {
+    expect(isValidNationalId("4993708")).toBe(false)
+  })
+
+  it("rejects more than 10 digits", () => {
+    expect(isValidNationalId("04993708991")).toBe(false)
+  })
+
+  it("treats 8-digit input as left-zero-padded equivalence", () => {
+    expect(isValidNationalId("17111110")).toBe(true)
+  })
+
+  it.each([null, undefined, "", "abc"])("rejects %p", (input) => {
+    // @ts-expect-error characterization of runtime null/undefined handling
+    expect(isValidNationalId(input)).toBe(false)
+  })
+
+  it("rejects values whose six middle digits are all zero", () => {
+    expect(isValidNationalId("0010000007")).toBe(false)
+  })
+
+  it("validates a checksum-correct ID on the r = 0 branch", () => {
+    // sum(0,0,1,7,1,1,1,1,1 weighted) = 77 → r = 0, check digit must be 0
+    expect(isValidNationalId("0017111110")).toBe(true)
+  })
+
+  it("validates a checksum-correct ID on the r >= 2 branch", () => {
+    // "0499370899": r = 266 % 11 = 2, check digit 11 - 2 = 9
+    expect(isValidNationalId("0499370899")).toBe(true)
+  })
+
+  it("enforces the issuance-prefix gate by default and bypasses it with checkPrefix: false", () => {
+    // Checksum-valid ID whose prefix "999" is absent from the prefix list
+    const unprefixed = "9991234561"
+    expect(isValidNationalId(unprefixed, { checkPrefix: false })).toBe(true)
+    expect(isValidNationalId(unprefixed)).toBe(false)
+  })
+
+  it("keeps validating after the gate when a present prefix is used", () => {
+    const { id } = generateValidId(3)
+    expect(isValidNationalId(id)).toBe(true)
+  })
+
+  it("accepts 50 deterministically generated checksum-valid IDs and rejects their check-digit mutations", () => {
+    let lowRemainders = 0
+    let highRemainders = 0
+
+    for (let i = 0; i < 50; i++) {
+      const { id, remainder } = generateValidId(i)
+      expect(isValidNationalId(id)).toBe(true)
+
+      const mutatedCheck = (Number(id[9]) + 1) % 10
+      const mutated = id.slice(0, 9) + String(mutatedCheck)
+      expect(mutated).not.toBe(id)
+      expect(isValidNationalId(mutated)).toBe(false)
+
+      if (remainder < 2) lowRemainders++
+      else highRemainders++
+    }
+
+    expect(lowRemainders).toBeGreaterThan(0)
+    expect(highRemainders).toBeGreaterThan(0)
+  })
+})

--- a/packages/ui/src/lib/normalize-persian-digits.test.ts
+++ b/packages/ui/src/lib/normalize-persian-digits.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizePersianDigits } from "./normalize-persian-digits.js"
+
+describe("normalizePersianDigits", () => {
+  it.each([
+    ["۰", "0"],
+    ["۱", "1"],
+    ["۲", "2"],
+    ["۳", "3"],
+    ["۴", "4"],
+    ["۵", "5"],
+    ["۶", "6"],
+    ["۷", "7"],
+    ["۸", "8"],
+    ["۹", "9"],
+  ])("maps Persian digit %s to %s", (input, expected) => {
+    expect(normalizePersianDigits(input)).toBe(expected)
+  })
+
+  it.each([
+    ["٠", "0"],
+    ["١", "1"],
+    ["٢", "2"],
+    ["٣", "3"],
+    ["٤", "4"],
+    ["٥", "5"],
+    ["٦", "6"],
+    ["٧", "7"],
+    ["٨", "8"],
+    ["٩", "9"],
+  ])("maps Arabic-Indic digit %s to %s", (input, expected) => {
+    expect(normalizePersianDigits(input)).toBe(expected)
+  })
+
+  it("normalizes digits inside a mixed string, leaving surrounding text intact", () => {
+    expect(normalizePersianDigits("قسمت ۱۲ از ٣ فصل")).toBe("قسمت 12 از 3 فصل")
+  })
+
+  it("leaves non-digit text untouched", () => {
+    expect(normalizePersianDigits("سلام دنیا ABC xyz!@#")).toBe(
+      "سلام دنیا ABC xyz!@#"
+    )
+  })
+
+  it("returns an empty string for empty input", () => {
+    expect(normalizePersianDigits("")).toBe("")
+  })
+})

--- a/packages/ui/src/lib/persian-slug.test.ts
+++ b/packages/ui/src/lib/persian-slug.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+
+import { toLatinSlug, toPersianSlug } from "./persian-slug.js"
+
+describe("toPersianSlug", () => {
+  // JSDoc examples, ported verbatim
+  it('converts plain Persian text: "راهنمای خرید گوشی موبایل" → "راهنمای-خرید-گوشی-موبایل"', () => {
+    expect(toPersianSlug("راهنمای خرید گوشی موبایل")).toBe(
+      "راهنمای-خرید-گوشی-موبایل"
+    )
+  })
+
+  it('handles mixed Persian/Latin text with ZWNJ and digits: "بهترین لپ‌تاپ های Gaming 2024" → "بهترین-لپتاپ-های-gaming-2024"', () => {
+    expect(toPersianSlug("بهترین لپ\u200cتاپ های Gaming 2024")).toBe(
+      "بهترین-لپتاپ-های-gaming-2024"
+    )
+  })
+
+  it('normalizes Persian digits by default: "مقاله ۱۲۳" → "مقاله-123"', () => {
+    expect(toPersianSlug("مقاله ۱۲۳")).toBe("مقاله-123")
+  })
+
+  it('strips punctuation and collapses whitespace: "  چطور   کیک، بپزیم؟!  " → "چطور-کیک-بپزیم"', () => {
+    expect(toPersianSlug("  چطور   کیک، بپزیم؟!  ")).toBe("چطور-کیک-بپزیم")
+  })
+
+  it('transliterates when requested: "سلام دنیا" → "slam-dnya"', () => {
+    expect(toPersianSlug("سلام دنیا", { transliterate: true })).toBe(
+      "slam-dnya"
+    )
+  })
+
+  it("supports a custom separator", () => {
+    expect(toPersianSlug("راهنمای خرید گوشی", { separator: "_" })).toBe(
+      "راهنمای_خرید_گوشی"
+    )
+  })
+
+  it("keeps Persian digits when normalizeDigits is false", () => {
+    expect(toPersianSlug("مقاله ۱۲۳", { normalizeDigits: false })).toBe(
+      "مقاله-۱۲۳"
+    )
+  })
+
+  it("folds Arabic-form characters to their Persian equivalents", () => {
+    expect(toPersianSlug("كتاب يوسف")).toBe("کتاب-یوسف")
+    expect(toPersianSlug("مؤمنة إيران أردیبهشت ٱ")).toBe(
+      "مومنه-ایران-اردیبهشت-ا"
+    )
+  })
+
+  it("is idempotent for already-slugified input", () => {
+    const slug = toPersianSlug("راهنمای خرید گوشی موبایل")
+    expect(toPersianSlug(slug)).toBe(slug)
+    const latin = toLatinSlug("سلام دنیا")
+    expect(toLatinSlug(latin)).toBe(latin)
+  })
+
+  it("lowercases the Latin portion of the output", () => {
+    expect(toPersianSlug("خرید iPhone")).toBe("خرید-iphone")
+  })
+
+  it.each(["", "   ", "!!!", "___"])("reduces %p to an empty string", (input) => {
+    expect(toPersianSlug(input)).toBe("")
+  })
+})
+
+describe("toLatinSlug", () => {
+  it("always transliterates: سلام دنیا → slam-dnya", () => {
+    expect(toLatinSlug("سلام دنیا")).toBe("slam-dnya")
+  })
+
+  it("produces fully ASCII output for mixed input and supports options", () => {
+    expect(toLatinSlug("گوشی ۱۲")).toBe("gvshy-12")
+    expect(toLatinSlug("سلام دنیا", { separator: "+" })).toBe(
+      "slam+dnya"
+    )
+  })
+
+  it("drops characters with no transliteration target instead of keeping them", () => {
+    expect(toLatinSlug("ءاب")).toBe("ab")
+  })
+})

--- a/packages/ui/src/lib/persian-slug.test.ts
+++ b/packages/ui/src/lib/persian-slug.test.ts
@@ -60,9 +60,12 @@ describe("toPersianSlug", () => {
     expect(toPersianSlug("خرید iPhone")).toBe("خرید-iphone")
   })
 
-  it.each(["", "   ", "!!!", "___"])("reduces %p to an empty string", (input) => {
-    expect(toPersianSlug(input)).toBe("")
-  })
+  it.each(["", "   ", "!!!", "___"])(
+    "reduces %p to an empty string",
+    (input) => {
+      expect(toPersianSlug(input)).toBe("")
+    }
+  )
 })
 
 describe("toLatinSlug", () => {
@@ -72,9 +75,7 @@ describe("toLatinSlug", () => {
 
   it("produces fully ASCII output for mixed input and supports options", () => {
     expect(toLatinSlug("گوشی ۱۲")).toBe("gvshy-12")
-    expect(toLatinSlug("سلام دنیا", { separator: "+" })).toBe(
-      "slam+dnya"
-    )
+    expect(toLatinSlug("سلام دنیا", { separator: "+" })).toBe("slam+dnya")
   })
 
   it("drops characters with no transliteration target instead of keeping them", () => {

--- a/packages/ui/src/lib/postal-code.test.ts
+++ b/packages/ui/src/lib/postal-code.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { isValidPostalCode } from "./postal-code.js"
+
+describe("isValidPostalCode", () => {
+  it.each([
+    ["1234567890", true],
+    ["9876543210", true],
+    ["123456789", false],
+    ["12345678901", false],
+    ["0234567890", false],
+    ["1111111111", false],
+    ["9999999999", false],
+  ])("validates %s as %s", (input, expected) => {
+    expect(isValidPostalCode(input)).toBe(expected)
+  })
+
+  it.each([null, undefined, ""])("rejects %p", (input) => {
+    // @ts-expect-error characterization of runtime null/undefined handling
+    expect(isValidPostalCode(input)).toBe(false)
+  })
+
+  it("accepts the Persian-digit equivalent of a valid code", () => {
+    expect(isValidPostalCode("۱۲۳۴۵۶۷۸۹۰")).toBe(true)
+  })
+
+  it("accepts a valid code containing separators by extracting digits only", () => {
+    expect(isValidPostalCode("12345-67890")).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Implements plans/007-validator-characterization-tests.md.

Adds the first-ever tests for the five pure validator/formatter modules that ship to consumers via `registry/base/lib`:

| Module | Cases | Coverage |
|--------|-------|----------|
| `normalize-persian-digits` | 23 | Persian ۰-۹ + Arabic-Indic ٠-٩ mappings, passthrough |
| `postal-code` | 12 | shape rules, leading-zero/repeated-digit rejects, Persian-digit input |
| `iranian-mobile` | 25 | all JSDoc formats (+98/0098/0/bare-9, separators, Persian digits), masking, round-trips |
| `persian-slug` | 17 | all JSDoc examples verbatim, custom separators, Arabic→Persian folding, idempotence |
| `national-id` | 19 | JSDoc fixtures, length/padding/prefix/middle-zeros rules, both checksum branches, deterministic property loop |

Pure characterization: current behavior pinned; source modules untouched. No suspected bugs surfaced — everything matched documented contracts. Suite grows **104 → 200 tests**, all green.

## Verification

- `cd packages/ui && bun run test` → 11 files / 200 passed
- lint + prettier clean; only the five new test files changed
