### PR TITLE
test(hooks): characterize countdown boundaries, media-query parser, controllable state

### DIFF
--- a/packages/ui/src/hooks/use-controllable-state.test.ts
+++ b/packages/ui/src/hooks/use-controllable-state.test.ts
@@ -23,7 +23,9 @@ describe("useControllableState", () => {
   })
 
   it("supports functional updates when uncontrolled", () => {
-    const { result } = renderHook(() => useControllableState({ defaultProp: 1 }))
+    const { result } = renderHook(() =>
+      useControllableState({ defaultProp: 1 })
+    )
 
     act(() => {
       result.current[1]((prev) => prev + 1)
@@ -35,7 +37,8 @@ describe("useControllableState", () => {
   it("invokes onChange on the setter and follows the prop when controlled", () => {
     const onChange = vi.fn()
     const { result, rerender } = renderHook(
-      ({ value }) => useControllableState({ prop: value, defaultProp: "a", onChange }),
+      ({ value }) =>
+        useControllableState({ prop: value, defaultProp: "a", onChange }),
       { initialProps: { value: "a" } }
     )
 
@@ -57,7 +60,8 @@ describe("useControllableState", () => {
   it("warns exactly once when switching between controlled and uncontrolled", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
     const { rerender } = renderHook(
-      ({ value }) => useControllableState({ prop: value, defaultProp: "a", caller: "Test" }),
+      ({ value }) =>
+        useControllableState({ prop: value, defaultProp: "a", caller: "Test" }),
       { initialProps: { value: undefined as string | undefined } }
     )
 

--- a/packages/ui/src/hooks/use-controllable-state.test.ts
+++ b/packages/ui/src/hooks/use-controllable-state.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useControllableState } from "./use-controllable-state.js"
+
+describe("useControllableState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders defaultValue and updates internal state when uncontrolled", () => {
+    const { result } = renderHook(() =>
+      useControllableState({ defaultProp: "a" })
+    )
+
+    expect(result.current[0]).toBe("a")
+
+    act(() => {
+      result.current[1]("b")
+    })
+
+    expect(result.current[0]).toBe("b")
+  })
+
+  it("supports functional updates when uncontrolled", () => {
+    const { result } = renderHook(() => useControllableState({ defaultProp: 1 }))
+
+    act(() => {
+      result.current[1]((prev) => prev + 1)
+    })
+
+    expect(result.current[0]).toBe(2)
+  })
+
+  it("invokes onChange on the setter and follows the prop when controlled", () => {
+    const onChange = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ value }) => useControllableState({ prop: value, defaultProp: "a", onChange }),
+      { initialProps: { value: "a" } }
+    )
+
+    expect(result.current[0]).toBe("a")
+
+    act(() => {
+      result.current[1]("b")
+    })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith("b")
+    // The displayed value still tracks the prop, not the setter argument.
+    expect(result.current[0]).toBe("a")
+
+    rerender({ value: "b" })
+    expect(result.current[0]).toBe("b")
+  })
+
+  it("warns exactly once when switching between controlled and uncontrolled", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const { rerender } = renderHook(
+      ({ value }) => useControllableState({ prop: value, defaultProp: "a", caller: "Test" }),
+      { initialProps: { value: undefined as string | undefined } }
+    )
+
+    rerender({ value: "controlled" })
+    rerender({ value: "controlled" })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      "Test is changing from uncontrolled to controlled"
+    )
+  })
+
+  it("uses the latest onChange after a rerender (no stale closure)", () => {
+    const firstOnChange = vi.fn()
+    const latestOnChange = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ onChange }) => useControllableState({ defaultProp: "a", onChange }),
+      { initialProps: { onChange: firstOnChange } }
+    )
+
+    rerender({ onChange: latestOnChange })
+
+    act(() => {
+      result.current[1]("b")
+    })
+
+    expect(latestOnChange).toHaveBeenCalledTimes(1)
+    expect(latestOnChange).toHaveBeenCalledWith("b")
+    expect(firstOnChange).not.toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/hooks/use-countdown.test.ts
+++ b/packages/ui/src/hooks/use-countdown.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useCountdown } from "./use-countdown.js"
+
+describe("useCountdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Seconds-only date keeps Date.now() aligned on a whole-second boundary.
+    vi.setSystemTime(new Date(2026, 7, 10, 12, 0, 0))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("ceilings a sub-second remainder up to the next second", () => {
+    const target = new Date(2026, 7, 10, 12, 0, 0, 500).toISOString()
+    const { result } = renderHook(() => useCountdown(target))
+
+    expect(result.current?.totalSeconds).toBe(1)
+    expect(result.current?.formatted).toBe("00:00:01")
+    expect(result.current?.isOverdue).toBe(false)
+  })
+
+  it("reports zero exactly at the target without flagging overdue", () => {
+    const target = new Date(2026, 7, 10, 12, 0, 0).toISOString()
+    const { result } = renderHook(() => useCountdown(target))
+
+    expect(result.current?.totalSeconds).toBe(0)
+    expect(result.current?.isOverdue).toBe(false)
+    expect(result.current?.formatted).toBe("00:00:00")
+  })
+
+  it("goes negative once the target has passed and formats the absolute value", () => {
+    const target = new Date(2026, 7, 10, 11, 59, 59).toISOString()
+    const { result } = renderHook(() => useCountdown(target))
+
+    expect(result.current?.totalSeconds).toBe(-1)
+    expect(result.current?.isOverdue).toBe(true)
+    expect(result.current?.formatted).toBe("00:00:01")
+    expect(result.current?.hours).toBe(0)
+    expect(result.current?.minutes).toBe(0)
+    expect(result.current?.seconds).toBe(1)
+  })
+
+  it("does not cap hours at 24 for multi-day targets", () => {
+    const now = new Date(2026, 7, 10, 12, 0, 0)
+    const target = new Date(now.getTime() + 48 * 3600_000 + 30_000)
+    const { result } = renderHook(() =>
+      useCountdown(target.toISOString())
+    )
+
+    expect(result.current?.hours).toBeGreaterThanOrEqual(48)
+    expect(result.current?.totalSeconds).toBeGreaterThan(0)
+  })
+
+  it("stays null for an invalid ISO string", () => {
+    const { result } = renderHook(() => useCountdown("not-a-date"))
+
+    expect(result.current).toBeNull()
+  })
+
+  it("stays null when the target is null", () => {
+    const { result } = renderHook(() => useCountdown(null))
+
+    expect(result.current).toBeNull()
+  })
+
+  it("updates itself across a second boundary and clears its timer on unmount", () => {
+    const now = new Date(2026, 7, 10, 12, 0, 0).getTime()
+    const target = new Date(now + 60_000).toISOString()
+    const { result, unmount } = renderHook(() => useCountdown(target))
+
+    expect(result.current?.totalSeconds).toBe(60)
+
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    // One self-rearmed update fires at +1000ms; ceil(59000/1000) === 59.
+    expect(result.current?.totalSeconds).toBe(59)
+
+    expect(vi.getTimerCount()).toBe(1)
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/packages/ui/src/hooks/use-countdown.test.ts
+++ b/packages/ui/src/hooks/use-countdown.test.ts
@@ -47,9 +47,7 @@ describe("useCountdown", () => {
   it("does not cap hours at 24 for multi-day targets", () => {
     const now = new Date(2026, 7, 10, 12, 0, 0)
     const target = new Date(now.getTime() + 48 * 3600_000 + 30_000)
-    const { result } = renderHook(() =>
-      useCountdown(target.toISOString())
-    )
+    const { result } = renderHook(() => useCountdown(target.toISOString()))
 
     expect(result.current?.hours).toBeGreaterThanOrEqual(48)
     expect(result.current?.totalSeconds).toBeGreaterThan(0)

--- a/packages/ui/src/hooks/use-media-query.test.ts
+++ b/packages/ui/src/hooks/use-media-query.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import { parseQuery } from "./use-media-query.js"
+
+// Real values from the module's BREAKPOINTS table:
+// sm=640, md=800, lg=1024, xl=1280, 2xl=1536, 3xl=1600, 4xl=2000
+describe("parseQuery", () => {
+  describe("object form", () => {
+    it("resolves a named min breakpoint", () => {
+      expect(parseQuery({ min: "md" })).toBe("(min-width: 800px)")
+    })
+
+    it("resolves a named max breakpoint one pixel below", () => {
+      expect(parseQuery({ max: "lg" })).toBe("(max-width: 1023px)")
+    })
+
+    it("joins min and max with `and`", () => {
+      expect(parseQuery({ min: "sm", max: "md" })).toBe(
+        "(min-width: 640px) and (max-width: 799px)"
+      )
+    })
+
+    it("resolves pointer coarse", () => {
+      expect(parseQuery({ pointer: "coarse" })).toBe("(pointer: coarse)")
+    })
+
+    it("uses numeric px values as-is for min", () => {
+      expect(parseQuery({ min: 500 })).toBe("(min-width: 500px)")
+    })
+
+    it("subtracts one pixel from a numeric max", () => {
+      expect(parseQuery({ max: 500 })).toBe("(max-width: 499px)")
+    })
+
+    it("falls back to a trivially-true query for an empty object", () => {
+      expect(parseQuery({})).toBe("(min-width: 0px)")
+    })
+  })
+
+  describe("string form starting with (", () => {
+    it("passes raw media queries through verbatim", () => {
+      expect(parseQuery("(prefers-reduced-motion: reduce)")).toBe(
+        "(prefers-reduced-motion: reduce)"
+      )
+    })
+  })
+
+  describe("breakpoint name form", () => {
+    it("resolves a single bare breakpoint as a min-width", () => {
+      expect(parseQuery("md")).toBe("(min-width: 800px)")
+    })
+
+    it("resolves max-<bp> one pixel below the breakpoint", () => {
+      expect(parseQuery("max-lg")).toBe("(max-width: 1023px)")
+    })
+
+    it("joins compound segments with `and` (each bare segment is a min)", () => {
+      expect(parseQuery("sm:md")).toBe(
+        "(min-width: 640px) and (min-width: 800px)"
+      )
+    })
+
+    it("drops unknown segments but keeps known ones", () => {
+      expect(parseQuery("bogus:md")).toBe("(min-width: 800px)")
+    })
+
+    it("returns the original string when every segment is unknown", () => {
+      expect(parseQuery("bogus:alsobogus")).toBe("bogus:alsobogus")
+    })
+  })
+})

--- a/packages/ui/src/hooks/use-media-query.ts
+++ b/packages/ui/src/hooks/use-media-query.ts
@@ -26,7 +26,10 @@ function resolveMax(value: Breakpoint | number): string {
   return `(max-width: ${px - 1}px)`
 }
 
-function parseQuery(
+/**
+ * @internal exported for unit tests; not part of the public API.
+ */
+export function parseQuery(
   query: BreakpointQuery | MediaQueryInput | (string & {})
 ): string {
   if (typeof query !== "string") {


### PR DESCRIPTION
## What

Implements plans/008-hooks-characterization-tests.md.

Adds characterization tests for the three logic-bearing hooks that had zero coverage:

- **`use-countdown`** (7 cases): ceiling semantics (500ms before target → `00:00:01`), exact-target zero, overdue sign flip with absolute formatting, hours ≥48 uncapped, invalid/null → `null`, self-rearming second-boundary timer, timer cleanup on unmount
- **`useMediaQuery.parseQuery`** (13 cases): object/name/passthrough forms against real breakpoint values, `max = px − 1` rule, compound `"sm:md"`, unknown-segment dropping
- **`use-controllable-state`** (5 cases): uncontrolled vs controlled contracts, mode-switch warn-once, no stale `onChange` after rerender

One source change: `parseQuery` exported with an `@internal` JSDoc line so the pure parser is testable directly — nothing else modified.

Suite grows **200 → 225 tests**, all green. Pure characterization: no behavior changes; countdown/controllable-state sources untouched.

## Verification

- `cd packages/ui && bun run test` → 14 files / 225 passed
- lint + prettier clean; scope = three new test files + the export keyword
