### PR TITLE
chore(web): add baseline security headers and report-only csp

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -35,6 +35,41 @@ const nextConfig: NextConfig = {
       { source: "/docs/:path*.md", destination: "/markdown/:path*" },
     ]
   },
+  // Baseline hardening for the public site. CSP ships report-only first:
+  // shiki emits inline styles and Next injects inline bootstrap scripts, so
+  // 'unsafe-inline' is required today; enforce (and tighten with nonces)
+  // after the report-only phase collects violations without noise.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+          // Preview frames iframe same-origin pages (components/preview-frame.tsx).
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          {
+            key: "Content-Security-Policy-Report-Only",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: https://images.unsplash.com https://github.com",
+              "font-src 'self' data:",
+              "connect-src 'self' https://va.vercel-scripts.com",
+              "frame-ancestors 'self'",
+              "object-src 'none'",
+              "base-uri 'self'",
+            ].join("; "),
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default createMDX()(nextConfig)


### PR DESCRIPTION
## What

Implements plans/011-security-response-headers.md.

Adds baseline security headers to the public site via `headers()` in `next.config.ts`:

| Header | Value |
|--------|-------|
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | camera/microphone/geolocation denied |
| `X-Frame-Options` | `SAMEORIGIN` — recon confirmed same-origin preview iframes (`components/preview-frame.tsx`) |
| `Content-Security-Policy-Report-Only` | default-src self; scripts self + inline (Next bootstrap) + va.vercel-scripts.com; styles self + inline (shiki); imgs self/data + unsplash + github; frame-ancestors self |

CSP ships **report-only** deliberately: shiki emits inline styles and Next injects inline bootstrap scripts, so enforcement needs a monitoring phase first. Flipping to enforcing is a separate maintainer decision once reports are clean.

## Recon documented

- Self-iframes: `preview-frame.tsx` embeds `/docs/<category>/<slug>?embed=1` → SAMEORIGIN, not DENY
- Analytics origin verified from installed `@vercel/analytics`: loads/beacons to `va.vercel-scripts.com`

## Verification (against production build)

All five headers present on responses · home/docs/`.md`/OG routes all 200 · build green
