### PR TITLE
feat(docs): tabbed install-all commands on the components page

### DIFF
--- a/apps/web/components/mdx/components-catalog.tsx
+++ b/apps/web/components/mdx/components-catalog.tsx
@@ -1,6 +1,12 @@
 import { CopyCommand } from "@/components/copy-command"
 import { ComponentsGrid } from "@/components/components-grid"
 import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs"
+import {
   AccordionPreview,
   AlertDialogPreview,
   AlertPreview,
@@ -94,6 +100,16 @@ function ThumbnailFrame({ children }: { children: React.ReactNode }) {
   )
 }
 
+/** Builds an install-all CLI command from registry items. Reads straight from
+ * registry.json so newly registered components/utilities appear automatically.
+ */
+function toInstallCommand(items: typeof registry.items) {
+  if (items.length === 0) return ""
+  return `npx shadcn@latest add ${items
+    .map((item) => `@persianlabsui/${item.name}`)
+    .join(" ")}`
+}
+
 /** The /docs/components catalog, extracted from the old page.tsx so the page
  * itself can be a markdown file. Badges come straight from docs-nav so the
  * gallery can never drift out of sync with the sidebar.
@@ -105,10 +121,17 @@ export function ComponentsCatalog() {
       .map((item) => [item.href, item.badge])
   )
 
-  const installAllCommand = `npx shadcn@latest add ${registry.items
-    .filter((item) => item.type === "registry:ui")
-    .map((item) => `@persianlabsui/${item.name}`)
-    .join(" ")}`
+  const installCommands = {
+    components: toInstallCommand(
+      registry.items.filter((item) => item.type === "registry:ui")
+    ),
+    utilities: toInstallCommand(
+      registry.items.filter(
+        (item) => item.type === "registry:lib" || item.type === "registry:hook"
+      )
+    ),
+    all: toInstallCommand(registry.items),
+  }
 
   const components = [
     {
@@ -1083,7 +1106,22 @@ export function ComponentsCatalog() {
   return (
     <>
       <div id="installation" className="mt-6 max-w-2xl">
-        <CopyCommand command={installAllCommand} />
+        <Tabs defaultValue="components">
+          <TabsList>
+            <TabsTrigger value="components">Components</TabsTrigger>
+            <TabsTrigger value="utilities">Utilities</TabsTrigger>
+            <TabsTrigger value="all">All</TabsTrigger>
+          </TabsList>
+          <TabsContent value="components" className="mt-3">
+            <CopyCommand command={installCommands.components} />
+          </TabsContent>
+          <TabsContent value="utilities" className="mt-3">
+            <CopyCommand command={installCommands.utilities} />
+          </TabsContent>
+          <TabsContent value="all" className="mt-3">
+            <CopyCommand command={installCommands.all} />
+          </TabsContent>
+        </Tabs>
       </div>
 
       <div id="catalog">


### PR DESCRIPTION
## Summary

The `/docs/components` installation section previously offered a single copy command covering only `registry:ui` items. It now renders a tabbed picker above the command box:

- **Components** — all `registry:ui` items (82)
- **Utilities** — all `registry:lib` + `registry:hook` items (17)
- **All** — every registry item combined (99)

## Dynamic source

All three commands are derived from `registry.json` at render time via a shared `toInstallCommand()` helper — no hardcoded name lists, so anything newly registered (component or utility) appears in the commands automatically.

Uses the existing `Tabs` primitives (`@workspace/ui/components/tabs`) and the `CopyCommand` box; the `#installation` anchor and ToC entry are unchanged.
