### PR TITLE
feat(docs): add CodeBlockCommand with PM switcher and AI prompt tab

### DIFF
--- a/apps/web/components/code-block-command.tsx
+++ b/apps/web/components/code-block-command.tsx
@@ -16,6 +16,14 @@ import {
 
 import type { PackageManager } from "@/lib/convert-npm-command"
 
+// Package managers first; any other key (the AI prompt) always renders last.
+const TAB_ORDER: PackageManager[] = ["pnpm", "yarn", "npm", "bun"]
+
+function tabRank(key: string): number {
+  const index = TAB_ORDER.indexOf(key as PackageManager)
+  return index === -1 ? TAB_ORDER.length : index
+}
+
 const packageManagerAtom = atomWithStorage<PackageManager>(
   "packageManager",
   "pnpm"
@@ -55,8 +63,12 @@ export function CodeBlockCommand({
     () => ({ prompt, pnpm, yarn, npm, bun }),
     [prompt, pnpm, yarn, npm, bun]
   )
+  // The AI prompt tab always renders last, whatever the prop order.
   const tabsFiltered = useMemo(
-    () => Object.entries(tabs).filter(([, value]) => !!value),
+    () =>
+      Object.entries(tabs)
+        .filter(([, value]) => !!value)
+        .sort(([a], [b]) => tabRank(a) - tabRank(b)),
     [tabs]
   )
 

--- a/apps/web/components/code-block-command.tsx
+++ b/apps/web/components/code-block-command.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { useMemo } from "react"
+import { TextAlignStartIcon, TerminalIcon } from "lucide-react"
+import { useAtom } from "jotai"
+import { useHydrateAtoms } from "jotai/react/utils"
+import { atomWithStorage } from "jotai/utils"
+
+import { CopyButton } from "@workspace/ui/components/copy-button"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs"
+
+import type { PackageManager } from "@/lib/convert-npm-command"
+
+const packageManagerAtom = atomWithStorage<PackageManager>(
+  "packageManager",
+  "pnpm"
+)
+
+interface CodeBlockCommandProps {
+  /** Natural language instruction shown under an AI prompt tab. */
+  prompt?: string
+  pnpm?: string
+  yarn?: string
+  npm?: string
+  bun?: string
+  /** Fires after the active command is copied, with the selected manager. */
+  onCopySuccess?: (data: {
+    packageManager: PackageManager
+    command: string
+  }) => void
+}
+
+/**
+ * Install-command block with a package-manager switcher. The chosen manager
+ * persists across visits (localStorage via jotai); SSR always renders the
+ * "pnpm" default so hydration never mismatches.
+ */
+export function CodeBlockCommand({
+  prompt,
+  pnpm,
+  yarn,
+  npm,
+  bun,
+  onCopySuccess,
+}: CodeBlockCommandProps) {
+  useHydrateAtoms([[packageManagerAtom, "pnpm"] as const])
+  const [packageManager, setPackageManager] = useAtom(packageManagerAtom)
+
+  const tabs = useMemo(
+    () => ({ prompt, pnpm, yarn, npm, bun }),
+    [prompt, pnpm, yarn, npm, bun]
+  )
+  const tabsFiltered = useMemo(
+    () => Object.entries(tabs).filter(([, value]) => !!value),
+    [tabs]
+  )
+
+  return (
+    <div
+      dir="ltr"
+      className="relative w-full min-w-0 overflow-hidden rounded-xl border border-border bg-card"
+    >
+      <Tabs
+        className="gap-0"
+        variant="line"
+        value={tabs[packageManager] ? packageManager : "pnpm"}
+        onValueChange={(value) => setPackageManager(value as PackageManager)}
+      >
+        <div className="w-full overflow-x-auto">
+          <TabsList className="h-10 w-full justify-start gap-1 rounded-none border-b border-border/60 px-3">
+            <span className="mr-1 flex size-4 shrink-0 items-center text-muted-foreground [&_svg]:size-4">
+              {getPackageManagerIcon(
+                tabs[packageManager] ? packageManager : "pnpm"
+              )}
+            </span>
+            {tabsFiltered.map(([key]) => (
+              <TabsTrigger
+                key={key}
+                value={key}
+                className="h-6 rounded-md px-2 font-mono text-xs"
+              >
+                {key}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
+
+        {tabsFiltered.map(([key, value]) => (
+          <TabsContent key={key} value={key}>
+            <pre
+              data-pm={key}
+              className="group/pm overscroll-x-contain p-4 leading-6 not-data-[pm=prompt]:overflow-x-auto"
+            >
+              <code
+                data-slot="code-block"
+                data-language="bash"
+                className="font-mono text-sm/none whitespace-pre text-muted-foreground group-data-[pm=prompt]/pm:whitespace-normal"
+              >
+                <span className="select-none group-data-[pm=prompt]/pm:hidden">
+                  ${" "}
+                </span>
+                {value}
+              </code>
+            </pre>
+          </TabsContent>
+        ))}
+      </Tabs>
+
+      <CopyButton
+        className="absolute top-2 right-2 z-10 size-6 rounded-md border-none [&_svg:not([class*='size-'])]:size-3.5"
+        size="icon-sm"
+        text={tabs[packageManager] || ""}
+        onCopySuccess={(copiedCommand) => {
+          onCopySuccess?.({
+            packageManager,
+            command: copiedCommand,
+          })
+        }}
+      />
+    </div>
+  )
+}
+
+function getPackageManagerIcon(manager: PackageManager) {
+  switch (manager) {
+    case "prompt":
+      return <TextAlignStartIcon />
+    case "pnpm":
+      return (
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M0 0v7.5h7.5V0zm8.25 0v7.5h7.498V0zm8.25 0v7.5H24V0zM8.25 8.25v7.5h7.498v-7.5zm8.25 0v7.5H24v-7.5zM0 16.5V24h7.5v-7.5zm8.25 0V24h7.498v-7.5zm8.25 0V24H24v-7.5z"
+            fill="currentColor"
+          />
+        </svg>
+      )
+    case "yarn":
+      return (
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M12 0C5.375 0 0 5.375 0 12s5.375 12 12 12 12-5.375 12-12S18.625 0 12 0zm.768 4.105c.183 0 .363.053.525.157.125.083.287.185.755 1.154.31-.088.468-.042.551-.019.204.056.366.19.463.375.477.917.542 2.553.334 3.605-.241 1.232-.755 2.029-1.131 2.576.324.329.778.899 1.117 1.825.278.774.31 1.478.273 2.015a5.51 5.51 0 0 0 .602-.329c.593-.366 1.487-.917 2.553-.931.714-.009 1.269.445 1.353 1.103a1.23 1.23 0 0 1-.945 1.362c-.649.158-.95.278-1.821.843-1.232.797-2.539 1.242-3.012 1.39a1.686 1.686 0 0 1-.704.343c-.737.181-3.266.315-3.466.315h-.046c-.783 0-1.214-.241-1.45-.491-.658.329-1.51.19-2.122-.134a1.078 1.078 0 0 1-.58-1.153 1.243 1.243 0 0 1-.153-.195c-.162-.25-.528-.936-.454-1.946.056-.723.556-1.367.88-1.71a5.522 5.522 0 0 1 .408-2.256c.306-.727.885-1.348 1.32-1.737-.32-.537-.644-1.367-.329-2.21.227-.602.412-.936.82-1.08h-.005c.199-.074.389-.153.486-.259a3.418 3.418 0 0 1 2.298-1.103c.037-.093.079-.185.125-.283.31-.658.639-1.029 1.024-1.168a.94.94 0 0 1 .328-.06zm.006.7c-.507.016-1.001 1.519-1.001 1.519s-1.27-.204-2.266.871c-.199.218-.468.334-.746.44-.079.028-.176.023-.417.672-.371.991.625 2.094.625 2.094s-1.186.839-1.626 1.881c-.486 1.144-.338 2.261-.338 2.261s-.843.732-.899 1.487c-.051.663.139 1.2.343 1.515.227.343.51.176.51.176s-.561.653-.037.931c.477.25 1.283.394 1.71-.037.31-.31.371-1.001.486-1.283.028-.065.12.111.209.199.097.093.264.195.264.195s-.755.324-.445 1.066c.102.246.468.403 1.066.398.222-.005 2.664-.139 3.313-.296.375-.088.505-.283.505-.283s1.566-.431 2.998-1.357c.917-.598 1.293-.76 2.034-.936.612-.148.57-1.098-.241-1.084-.839.009-1.575.44-2.196.825-1.163.718-1.742.672-1.742.672l-.018-.032c-.079-.13.371-1.293-.134-2.678-.547-1.515-1.413-1.881-1.344-1.997.297-.5 1.038-1.297 1.334-2.78.176-.899.13-2.377-.269-3.151-.074-.144-.732.241-.732.241s-.616-1.371-.788-1.483a.271.271 0 0 0-.157-.046z"
+            fill="currentColor"
+          />
+        </svg>
+      )
+    case "npm":
+      return (
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z"
+            fill="currentColor"
+          />
+        </svg>
+      )
+    case "bun":
+      return (
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M12 22.596c6.628 0 12-4.338 12-9.688 0-3.318-2.057-6.248-5.219-7.986-1.286-.715-2.297-1.357-3.139-1.89C14.058 2.025 13.08 1.404 12 1.404c-1.097 0-2.334.785-3.966 1.821a49.92 49.92 0 0 1-2.816 1.697C2.057 6.66 0 9.59 0 12.908c0 5.35 5.372 9.687 12 9.687v.001ZM10.599 4.715c.334-.759.503-1.58.498-2.409 0-.145.202-.187.23-.029.658 2.783-.902 4.162-2.057 4.624-.124.048-.199-.121-.103-.209a5.763 5.763 0 0 0 1.432-1.977Zm2.058-.102a5.82 5.82 0 0 0-.782-2.306v-.016c-.069-.123.086-.263.185-.172 1.962 2.111 1.307 4.067.556 5.051-.082.103-.23-.003-.189-.126a5.85 5.85 0 0 0 .23-2.431Zm1.776-.561a5.727 5.727 0 0 0-1.612-1.806v-.014c-.112-.085-.024-.274.114-.218 2.595 1.087 2.774 3.18 2.459 4.407a.116.116 0 0 1-.049.071.11.11 0 0 1-.153-.026.122.122 0 0 1-.022-.083 5.891 5.891 0 0 0-.737-2.331Zm-5.087.561c-.617.546-1.282.76-2.063 1-.117 0-.195-.078-.156-.181 1.752-.909 2.376-1.649 2.999-2.778 0 0 .155-.118.188.085 0 .304-.349 1.329-.968 1.874Zm4.945 11.237a2.957 2.957 0 0 1-.937 1.553c-.346.346-.8.565-1.286.62a2.178 2.178 0 0 1-1.327-.62 2.955 2.955 0 0 1-.925-1.553.244.244 0 0 1 .064-.198.234.234 0 0 1 .193-.069h3.965a.226.226 0 0 1 .19.07c.05.053.073.125.063.197Zm-5.458-2.176a1.862 1.862 0 0 1-2.384-.245 1.98 1.98 0 0 1-.233-2.447c.207-.319.503-.566.848-.713a1.84 1.84 0 0 1 1.092-.11c.366.075.703.261.967.531a1.98 1.98 0 0 1 .408 2.114 1.931 1.931 0 0 1-.698.869v.001Zm8.495.005a1.86 1.86 0 0 1-2.381-.253 1.964 1.964 0 0 1-.547-1.366c0-.384.11-.76.32-1.079.207-.319.503-.567.849-.713a1.844 1.844 0 0 1 1.093-.108c.367.076.704.262.968.534a1.98 1.98 0 0 1 .4 2.117 1.932 1.932 0 0 1-.702.868Z"
+            fill="currentColor"
+          />
+        </svg>
+      )
+    default:
+      return <TerminalIcon />
+  }
+}

--- a/apps/web/components/install-command.tsx
+++ b/apps/web/components/install-command.tsx
@@ -1,35 +1,6 @@
-"use client"
-
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@workspace/ui/components/tabs"
-
-import { CopyCommand } from "@/components/copy-command"
-
-const PACKAGE_MANAGERS = [
-  { value: "pnpm", label: "pnpm", command: "pnpm add" },
-  { value: "npm", label: "npm", command: "npm install" },
-  { value: "bun", label: "bun", command: "bun add" },
-] as const
+import { CodeBlockCommand } from "@/components/code-block-command"
+import { convertNpmCommand } from "@/lib/convert-npm-command"
 
 export function InstallCommand({ packages }: { packages: string }) {
-  return (
-    <Tabs defaultValue="pnpm" variant="line">
-      <TabsList>
-        {PACKAGE_MANAGERS.map((pm) => (
-          <TabsTrigger key={pm.value} value={pm.value}>
-            {pm.label}
-          </TabsTrigger>
-        ))}
-      </TabsList>
-      {PACKAGE_MANAGERS.map((pm) => (
-        <TabsContent key={pm.value} value={pm.value}>
-          <CopyCommand command={`${pm.command} ${packages}`} />
-        </TabsContent>
-      ))}
-    </Tabs>
-  )
+  return <CodeBlockCommand {...convertNpmCommand(`npm install ${packages}`)} />
 }

--- a/apps/web/components/mdx/components-catalog.tsx
+++ b/apps/web/components/mdx/components-catalog.tsx
@@ -1,5 +1,6 @@
-import { CopyCommand } from "@/components/copy-command"
+import { CodeBlockCommand } from "@/components/code-block-command"
 import { ComponentsGrid } from "@/components/components-grid"
+import { convertNpmCommand } from "@/lib/convert-npm-command"
 import {
   Tabs,
   TabsContent,
@@ -1126,13 +1127,22 @@ export function ComponentsCatalog() {
             <TabsTrigger value="all">All</TabsTrigger>
           </TabsList>
           <TabsContent value="components" className="mt-3">
-            <CopyCommand command={installCommands.components} />
+            <CodeBlockCommand
+              prompt="Add every PersianLabs UI component to my project"
+              {...convertNpmCommand(installCommands.components)}
+            />
           </TabsContent>
           <TabsContent value="utilities" className="mt-3">
-            <CopyCommand command={installCommands.utilities} />
+            <CodeBlockCommand
+              prompt="Add every PersianLabs UI utility to my project"
+              {...convertNpmCommand(installCommands.utilities)}
+            />
           </TabsContent>
           <TabsContent value="all" className="mt-3">
-            <CopyCommand command={installCommands.all} />
+            <CodeBlockCommand
+              prompt="Install the whole PersianLabs UI registry at once"
+              {...convertNpmCommand(installCommands.all)}
+            />
           </TabsContent>
         </Tabs>
       </div>

--- a/apps/web/components/mdx/components-catalog.tsx
+++ b/apps/web/components/mdx/components-catalog.tsx
@@ -1128,19 +1128,19 @@ export function ComponentsCatalog() {
           </TabsList>
           <TabsContent value="components" className="mt-3">
             <CodeBlockCommand
-              prompt="Add every PersianLabs UI component to my project"
+              prompt="Install every PersianLabs UI component with the shadcn CLI. The full agent-facing catalog lives at https://ui.persian-labs.ir/llms.txt"
               {...convertNpmCommand(installCommands.components)}
             />
           </TabsContent>
           <TabsContent value="utilities" className="mt-3">
             <CodeBlockCommand
-              prompt="Add every PersianLabs UI utility to my project"
+              prompt="Install every PersianLabs UI utility with the shadcn CLI. The full agent-facing catalog lives at https://ui.persian-labs.ir/llms.txt"
               {...convertNpmCommand(installCommands.utilities)}
             />
           </TabsContent>
           <TabsContent value="all" className="mt-3">
             <CodeBlockCommand
-              prompt="Install the whole PersianLabs UI registry at once"
+              prompt="Install the whole PersianLabs UI registry — components and utilities — with the shadcn CLI. Browse what ships at https://ui.persian-labs.ir/llms.txt"
               {...convertNpmCommand(installCommands.all)}
             />
           </TabsContent>

--- a/apps/web/components/mdx/install-tabs.tsx
+++ b/apps/web/components/mdx/install-tabs.tsx
@@ -1,7 +1,8 @@
-import { CopyCommand } from "@/components/copy-command"
+import { CodeBlockCommand } from "@/components/code-block-command"
 import { InstallCommand } from "@/components/install-command"
 import { ComponentSourceDoc } from "@/components/mdx/component-source-doc"
 import { Step, Steps } from "@/components/steps"
+import { convertNpmCommand } from "@/lib/convert-npm-command"
 import {
   Tabs,
   TabsContent,
@@ -53,7 +54,7 @@ export function InstallTabs({
       </TabsList>
 
       <TabsContent value="cli" className="mt-4">
-        <CopyCommand command={command} />
+        <CodeBlockCommand {...convertNpmCommand(command)} />
       </TabsContent>
 
       <TabsContent value="manual" className="mt-4">

--- a/apps/web/content/docs/components/data-table.mdx
+++ b/apps/web/content/docs/components/data-table.mdx
@@ -8,15 +8,15 @@ Powerful tables and datagrids built with [TanStack Table](https://tanstack.com/t
 <LastEdited path="apps/web/content/docs/components/data-table.mdx" />
 
 <Credits
-          sources={[
-            { label: "shadcn/ui", href: "https://ui.shadcn.com" },
-            {
-              label: "TanStack Table",
-              href: "https://tanstack.com/table/latest/docs/introduction",
-            },
-          ]}
-          changed={false}
-        />
+  sources={[
+    { label: "shadcn/ui", href: "https://ui.shadcn.com" },
+    {
+      label: "TanStack Table",
+      href: "https://tanstack.com/table/latest/docs/introduction",
+    },
+  ]}
+  changed={false}
+/>
 
 Every data table or datagrid is unique: they behave differently, have specific sorting and filtering requirements, and work with different data sources. Rather than one rigid component, this guide shows how to build your own on top of the headless `@tanstack/react-table` library and our `<Table />` component.
 
@@ -29,7 +29,13 @@ Every data table or datagrid is unique: they behave differently, have specific s
 <Steps className="mt-4">
 <Step>Add the Table component to your project</Step>
 
-<CopyCommand command="npx shadcn@latest add @persianlabsui/table" />
+<CodeBlockCommand
+  prompt="Add the Table component to my project"
+  pnpm="pnpm dlx shadcn@latest add @persianlabsui/table"
+  yarn="yarn dlx shadcn@latest add @persianlabsui/table"
+  npm="npx shadcn@latest add @persianlabsui/table"
+  bun="bunx --bun shadcn@latest add @persianlabsui/table"
+/>
 
 <Step>Add the TanStack Table dependency. This guide uses v9:</Step>
 
@@ -72,7 +78,6 @@ TanStack Table v9 is feature-based: you opt into behavior — sorting, filtering
 
 ```tsx
 import {
-
   columnFilteringFeature,
   columnVisibilityFeature,
   createFilteredRowModel,
@@ -154,7 +159,6 @@ export const columns = columnHelper.columns([
 import { useTable } from "@tanstack/react-table"
 
 import {
-
   Table,
   TableBody,
   TableCell,
@@ -212,7 +216,7 @@ export function DataTable<TData extends RowData>({
                 ))}
               </TableRow>
             ))
-          ): (
+          ) : (
             <TableRow>
               <TableCell colSpan={columns.length} className="h-24 text-center">
                 No results.
@@ -393,8 +397,7 @@ Add a search input that filters the email column through the registered `include
 
 ```tsx
 const [sorting, setSorting] = React.useState<SortingState>([])
-const [columnFilters, setColumnFilters] =
-  React.useState<ColumnFiltersState>([])
+const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
 
 const table = useTable({
   features,
@@ -488,9 +491,9 @@ columnHelper.display({
   enableHiding: false,
 })
 ```
+
 ```tsx
-const [rowSelection, setRowSelection] =
-  React.useState<RowSelectionState>({})
+const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({})
 
 const table = useTable({
   features,
@@ -502,6 +505,7 @@ const table = useTable({
   },
 })
 ```
+
 ```tsx
 <div className="flex-1 text-sm text-muted-foreground">
   {table.getFilteredSelectedRowModel().rows.length} of{" "}

--- a/apps/web/content/docs/components/data-table.mdx
+++ b/apps/web/content/docs/components/data-table.mdx
@@ -30,7 +30,7 @@ Every data table or datagrid is unique: they behave differently, have specific s
 <Step>Add the Table component to your project</Step>
 
 <CodeBlockCommand
-  prompt="Add the Table component to my project"
+  prompt="Add @persianlabsui/table to my project, then wire up TanStack Table. The full agent catalog lives at https://ui.persian-labs.ir/llms.txt"
   pnpm="pnpm dlx shadcn@latest add @persianlabsui/table"
   yarn="yarn dlx shadcn@latest add @persianlabsui/table"
   npm="npx shadcn@latest add @persianlabsui/table"

--- a/apps/web/content/docs/utilities/hitbox.mdx
+++ b/apps/web/content/docs/utilities/hitbox.mdx
@@ -29,7 +29,13 @@ Hitbox preserves the child's semantics while adding an invisible touch target ar
 </TabsList>
 
 <TabsContent value="cli" className="mt-4">
-  <CopyCommand command="npx shadcn@latest add @persianlabsui/hitbox" />
+  <CodeBlockCommand
+    prompt="Add the Hitbox utility to my project"
+    pnpm="pnpm dlx shadcn@latest add @persianlabsui/hitbox"
+    yarn="yarn dlx shadcn@latest add @persianlabsui/hitbox"
+    npm="npx shadcn@latest add @persianlabsui/hitbox"
+    bun="bunx --bun shadcn@latest add @persianlabsui/hitbox"
+  />
 </TabsContent>
 
 <TabsContent value="manual" className="mt-4">

--- a/apps/web/content/docs/utilities/hitbox.mdx
+++ b/apps/web/content/docs/utilities/hitbox.mdx
@@ -30,7 +30,7 @@ Hitbox preserves the child's semantics while adding an invisible touch target ar
 
 <TabsContent value="cli" className="mt-4">
   <CodeBlockCommand
-    prompt="Add the Hitbox utility to my project"
+    prompt="Add the Hitbox utility to my project. It extends any element's clickable area — see https://ui.persian-labs.ir/llms.txt for the full agent catalog"
     pnpm="pnpm dlx shadcn@latest add @persianlabsui/hitbox"
     yarn="yarn dlx shadcn@latest add @persianlabsui/hitbox"
     npm="npx shadcn@latest add @persianlabsui/hitbox"

--- a/apps/web/lib/convert-npm-command.ts
+++ b/apps/web/lib/convert-npm-command.ts
@@ -1,0 +1,81 @@
+/** Package managers — plus the AI "prompt" tab — a command block switches between. */
+export type PackageManager = "prompt" | "pnpm" | "yarn" | "npm" | "bun"
+
+/**
+ * Result of converting an npm command to every package manager.
+ */
+export interface ConvertNpmCommandResult {
+  /** Command for pnpm. */
+  pnpm: string
+  /** Command for yarn. */
+  yarn: string
+  /** Command for npm. */
+  npm: string
+  /** Command for bun. */
+  bun: string
+}
+
+/**
+ * Converts a standard npm command into equivalent commands for pnpm, yarn,
+ * npm, and bun — the result spreads directly into `CodeBlockCommand`.
+ *
+ * Supported patterns: `npm install …`, `npx create-…`, `npm create …`,
+ * `npx …`, `npm run …`. Anything else passes through unchanged.
+ *
+ * Lives outside the client component so Server Components (InstallTabs,
+ * components-catalog) can call it during render without an RSC violation.
+ */
+export function convertNpmCommand(npmCommand: string): ConvertNpmCommandResult {
+  if (npmCommand.startsWith("npm install")) {
+    return {
+      pnpm: npmCommand.replaceAll("npm install", "pnpm add"),
+      yarn: npmCommand.replaceAll("npm install", "yarn add"),
+      npm: npmCommand,
+      bun: npmCommand.replaceAll("npm install", "bun add"),
+    }
+  }
+
+  // npx create- must be checked before the generic npx branch.
+  if (npmCommand.startsWith("npx create-")) {
+    return {
+      pnpm: npmCommand.replace("npx create-", "pnpm create "),
+      yarn: npmCommand.replace("npx create-", "yarn create "),
+      npm: npmCommand,
+      bun: npmCommand.replace("npx", "bunx --bun"),
+    }
+  }
+
+  if (npmCommand.startsWith("npm create")) {
+    return {
+      pnpm: npmCommand.replace("npm create", "pnpm create"),
+      yarn: npmCommand.replace("npm create", "yarn create"),
+      npm: npmCommand,
+      bun: npmCommand.replace("npm create", "bun create"),
+    }
+  }
+
+  if (npmCommand.startsWith("npx")) {
+    return {
+      pnpm: npmCommand.replace("npx", "pnpm dlx"),
+      yarn: npmCommand.replace("npx", "yarn dlx"),
+      npm: npmCommand,
+      bun: npmCommand.replace("npx", "bunx --bun"),
+    }
+  }
+
+  if (npmCommand.startsWith("npm run")) {
+    return {
+      pnpm: npmCommand.replace("npm run", "pnpm"),
+      yarn: npmCommand.replace("npm run", "yarn"),
+      npm: npmCommand,
+      bun: npmCommand.replace("npm run", "bun"),
+    }
+  }
+
+  return {
+    pnpm: npmCommand,
+    yarn: npmCommand,
+    npm: npmCommand,
+    bun: npmCommand,
+  }
+}

--- a/apps/web/lib/markdown-docs.ts
+++ b/apps/web/lib/markdown-docs.ts
@@ -94,6 +94,13 @@ export function processMarkdownForLlms(raw: string): string {
     (_match, command: string) => `${FENCE}bash\n${command}\n${FENCE}`
   )
 
+  // 7b. Multi-manager install blocks collapse to their npm form, matching
+  //     what the on-site widget defaults to copying conceptually.
+  content = content.replace(
+    /<CodeBlockCommand[\s\S]*?\bnpm="([^"]+)"[\s\S]*?\/>/g,
+    (_match, command: string) => `${FENCE}bash\n${command}\n${FENCE}`
+  )
+
   // 8. API reference islands become GFM tables via the same rows the UI
   //    renders.
   content = content.replace(

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -3,6 +3,7 @@ import type { Route } from "next"
 import * as React from "react"
 
 import { CopyCommand } from "@/components/copy-command"
+import { CodeBlockCommand } from "@/components/code-block-command"
 import { InstallCommand } from "@/components/install-command"
 import {
   Tabs,
@@ -196,6 +197,7 @@ export const mdxComponents = {
 
   Link,
   CopyCommand: DocCopyCommand,
+  CodeBlockCommand,
   InstallCommand,
   InstallTabs,
   CodeBlock,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "fumadocs-docgen": "^3.1.0",
     "fumadocs-mdx": "^15.3.1",
     "input-otp": "^1.5.0",
+    "jotai": "^2.20.3",
     "lucide": "^1.33.0",
     "lucide-react": "^1.33.0",
     "morphicons": "^1.7.0",

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "fumadocs-docgen": "^3.1.0",
         "fumadocs-mdx": "^15.3.1",
         "input-otp": "^1.5.0",
+        "jotai": "^2.20.3",
         "lucide": "^1.33.0",
         "lucide-react": "^1.33.0",
         "morphicons": "^1.7.0",
@@ -1301,6 +1302,8 @@
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
+
+    "jotai": ["jotai@2.20.3", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-N8L9FUbeGDP+0qNJw1FebOxt+5hk+jTOwUA2LlRE4C081jUcY6F1T/FSETp4DT2/INMtiSRZyNm2D+yZdzrSgA=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 


### PR DESCRIPTION
﻿## What

Adds a **CodeBlockCommand** install widget with a package-manager switcher and an AI-`prompt` tab, and wires it through every install surface on the docs site. The prompt tab always renders last, and prompts reference the agent-facing catalog at `https://ui.persian-labs.ir/llms.txt`.

## Behavior

- **PM switcher** `pnpm / yarn / npm / bun` with `$` prefix and a copy button — the chosen manager persists across visits (localStorage via jotai), defaulting to **pnpm** and SSR-seeded so hydration never mismatches.
- **Prompt tab** always renders last, whatever the object-insertion order.
- `dir="ltr"` pin so command text stays correct inside RTL Persian docs.

## Where it's wired

- `InstallTabs` CLI panel (every component/utility page) — via `convertNpmCommand`.
- `InstallCommand` deps block inside Manual tabs (data-table, hitbox, etc.).
- `/docs/components` catalog — Components / Utilities / All rows, each with its own prompt tab.
- Direct `data-table.mdx` / `hitbox.mdx` install islands.
- `.md` endpoint: `markdown-docs.ts` expands `<CodeBlockCommand>` islands to their `npm=` fence, so `/docs/*.md` output stays clean (verified: no leaked JSX, correct npm command).

## Adaptations (no upstream credit, per maintainer's request)

Built from a chanhdai component but re-implemented on this repo's `@workspace/ui` Tabs (`variant="line"`) and CopyButton, dropping `IconSwap`/ScrollArea for a plain overflow header. Only new dependency added: **`jotai`** (no radix-ui). `convertNpmCommand` lives in `apps/web/lib/convert-npm-command.ts` (server-safe) so Server Components can call it without an RSC violation.

## Commits

- `f9d69ed` feat: add CodeBlockCommand + wire into all surfaces
- `929acfc` feat: render prompt tab last (rank-based sort, fixes indexOf-first bug)
- `31f5df9` docs: actionable prompts + llms.txt references

## Verified

- `bun run typecheck` (all packages) ✓ · `bun run lint` ✓ · MDX guard ✓ · Prettier ✓
- Live: `prompt-last` confirmed on `/docs/components` and `/docs/components/data-table`; `.md` endpoints emit the npm fence with no island leakage.
