### PR TITLE
feat(header): GitHubStars pill with compact count + full-count tooltip

### DIFF
--- a/apps/web/components/github-stars.tsx
+++ b/apps/web/components/github-stars.tsx
@@ -2,44 +2,92 @@
 
 import { useEffect, useState } from "react"
 
-function formatStarCount(count: number): string {
-  return count >= 1000
-    ? `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`
-    : count.toString()
+import { Button } from "@workspace/ui/components/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@workspace/ui/components/tooltip"
+
+import { GithubIcon } from "@/components/icons"
+
+export interface GitHubStarsProps {
+  /** GitHub repository in `owner/repo` form. */
+  repo: string
+  /**
+   * Optional locales for number formatting.
+   * @defaultValue "en-US"
+   */
+  locales?: Intl.LocalesArgument
 }
 
-export function GithubStars() {
+function compactCount(count: number, locales: Intl.LocalesArgument): string {
+  return new Intl.NumberFormat(locales, {
+    notation: "compact",
+    compactDisplay: "short",
+  })
+    .format(count)
+    .toLowerCase()
+}
+
+/**
+ * A GitHub link (styled as a ghost button) showing the repo's star count in
+ * compact form, with a tooltip revealing the full count on hover. The count
+ * is fetched from the public GitHub API after mount and the link stays
+ * clickable even while — or if — the fetch fails.
+ */
+export function GitHubStars({ repo, locales = "en-US" }: GitHubStarsProps) {
   const [stars, setStars] = useState<number | null>(null)
 
   useEffect(() => {
     const controller = new AbortController()
+
     async function loadStars() {
       try {
-        const response = await fetch(
-          "https://api.github.com/repos/persianlabs/ui",
-          { signal: controller.signal }
-        )
+        const response = await fetch(`https://api.github.com/repos/${repo}`, {
+          signal: controller.signal,
+          headers: { Accept: "application/vnd.github+json" },
+        })
         if (!response.ok) return
         const data = (await response.json()) as { stargazers_count?: number }
-        if (typeof data.stargazers_count === "number")
+        if (typeof data.stargazers_count === "number") {
           setStars(data.stargazers_count)
+        }
       } catch {
-        // The GitHub link remains useful when the public API is unavailable.
+        // The repo link remains useful when the public API is unavailable.
       }
     }
+
     void loadStars()
     return () => controller.abort()
-  }, [])
+  }, [repo])
 
-  if (stars === null) return null
+  const href = `https://github.com/${repo}`
 
   return (
-    <span className="text-xs text-muted-foreground tabular-nums">
-      {formatStarCount(stars)}
-    </span>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 ps-2 pe-1.5"
+            render={<a href={href} target="_blank" rel="noreferrer" />}
+          >
+            <GithubIcon className="size-4" />
+            {stars !== null && (
+              <span className="text-[0.8125rem]/none text-muted-foreground tabular-nums">
+                {compactCount(stars, locales)}
+              </span>
+            )}
+          </Button>
+        }
+      />
+      {stars !== null && (
+        <TooltipContent className="tabular-nums">
+          {new Intl.NumberFormat(locales).format(stars)} stars
+        </TooltipContent>
+      )}
+    </Tooltip>
   )
-}
-
-export function GithubStarsFallback() {
-  return null
 }

--- a/apps/web/components/github-stars.tsx
+++ b/apps/web/components/github-stars.tsx
@@ -71,6 +71,7 @@ export function GitHubStars({ repo, locales = "en-US" }: GitHubStarsProps) {
           <Button
             variant="ghost"
             size="sm"
+            nativeButton={false}
             className="gap-1.5 ps-2 pe-1.5"
             render={<a href={href} target="_blank" rel="noreferrer" />}
           >

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link"
 
 import { AppLogo } from "@/components/app-logo"
-import { GithubStars } from "@/components/github-stars"
-import { GithubIcon, XIcon } from "@/components/icons"
+import { GitHubStars } from "@/components/github-stars"
+import { XIcon } from "@/components/icons"
 import { MobileNav } from "@/components/mobile-nav"
 import { SiteSearch } from "@/components/site-search"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { GITHUB_URL } from "@/lib/github"
+import { GITHUB_REPO } from "@/lib/github"
 
 const navLinks = [
   { href: "/docs", label: "Docs" },
@@ -56,16 +56,7 @@ export function SiteHeader({
 
         <div className="flex items-center gap-3">
           <SiteSearch />
-          <a
-            href={GITHUB_URL}
-            target="_blank"
-            rel="noreferrer"
-            aria-label="View PersianLabs/ui on GitHub"
-            className="flex h-7 items-center gap-2 rounded-md border border-border px-2.5 transition-colors hover:bg-muted"
-          >
-            <GithubIcon className="size-4" />
-            <GithubStars />
-          </a>
+          <GitHubStars repo={GITHUB_REPO} />
           <a
             href="https://x.com/taymakz"
             target="_blank"


### PR DESCRIPTION
﻿## What

Adds a **GitHubStars** component (adapted to Base UI) and mounts it in the site header, replacing the old count-only span rendered inside a bespoke anchor.

## Component

- Ghost `Button` (Base UI) that renders as an `<a>` to the repo via the `render` prop — no radix.
- Compact star count via `Intl.NumberFormat` notation="compact" (e.g. `1.2k`), lowercased, tabular-nums, with optical padding for the GitHub icon.
- A Base UI `Tooltip` on hover reveals the **full** count ("1234 stars").
- Count is fetched client-side after mount; the link icon stays visible and clickable even while the count loads or the API is down (SSR-safe — no hydration mismatch).

## Header

`<GitHubStars repo="persianlabs/ui" />` sits where the old bordered anchor was. Dropped the now-unused `GithubIcon`/`GITHUB_URL` import; uses `GITHUB_REPO`.

## Verified
- Prettier ✓ · ESLint ✓ · root typecheck ✓
- Live: header renders the GitHub link; compact count appears post-hydration (expected for client fetch).
