### PR TITLE
feat(docs): getting-started pages + Blocks & Templates roadmap

### DIFF
--- a/apps/web/app/(roadmap)/blocks/page.tsx
+++ b/apps/web/app/(roadmap)/blocks/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next"
+
+import { RoadmapPage, type RoadmapPhase } from "@/components/roadmap-page"
+
+export const metadata: Metadata = {
+  title: "Blocks",
+  description:
+    "The roadmap for copy-paste Blocks on PersianLabs/ui - built on a stable component base first.",
+}
+
+const phases: RoadmapPhase[] = [
+  {
+    title: "Solidify the library",
+    status: "now",
+    tagline: "Blocks are only as good as the primitives they're built from.",
+    items: [
+      "Expand component and utility coverage across every form, layout, and feedback need",
+      "Stabilize public APIs and harden RTL edge cases",
+      "Grow the automated test suite and keep the registry green",
+    ],
+  },
+  {
+    title: "Design the block system",
+    status: "next",
+    tagline: "Agree on the building blocks before shipping them.",
+    items: [
+      "Define a block taxonomy — auth, dashboards, pricing, e-commerce, settings",
+      "Create a reusable block authoring template with previews and one-command installs",
+      "Ensure every block themes through a single set of tokens",
+    ],
+  },
+  {
+    title: "Ship Blocks",
+    status: "later",
+    tagline: "Full-page sections, ready for real products.",
+    items: [
+      "Publish a growing catalog of copy-paste blocks with live previews",
+      "Add one-click install through the registry",
+      "Open the floor to community-contributed blocks",
+    ],
+  },
+]
+
+export default function BlocksPage() {
+  return (
+    <RoadmapPage
+      eyebrow="Roadmap"
+      title="Blocks"
+      description="Ready-made sections you can copy, paste, and own — auth flows, dashboards, pricing, and more. We're finishing a rock-solid component base first so every block is built on stable primitives."
+      phases={phases}
+    />
+  )
+}

--- a/apps/web/app/(roadmap)/layout.tsx
+++ b/apps/web/app/(roadmap)/layout.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react"
+
+import { SiteHeader } from "@/components/site-header"
+
+/**
+ * Shared layout for the /blocks and /templates roadmap pages — a different
+ * shell from the docs (top-level, no sidebar), but reusing the same header.
+ */
+export default function RoadmapLayout({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  return (
+    <div className="flex min-h-svh flex-col">
+      <SiteHeader showMobileNav />
+      <main className="w-full flex-1">{children}</main>
+    </div>
+  )
+}

--- a/apps/web/app/(roadmap)/templates/page.tsx
+++ b/apps/web/app/(roadmap)/templates/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next"
+
+import { RoadmapPage, type RoadmapPhase } from "@/components/roadmap-page"
+
+export const metadata: Metadata = {
+  title: "Templates",
+  description:
+    "The roadmap for Templates and the marketplace on PersianLabs/ui - free and paid templates, public and private repos.",
+}
+
+const phases: RoadmapPhase[] = [
+  {
+    title: "Free templates",
+    status: "next",
+    tagline: "Start-from templates to kick off real projects.",
+    items: [
+      "A handful of polished, production-leaning starter templates",
+      "Admin dashboard, marketing site, and e-commerce layouts",
+      "Built entirely with PersianLabs UI — RTL-first, no vendored CSS",
+    ],
+  },
+  {
+    title: "Paid templates & marketplace",
+    status: "later",
+    tagline: "A place to buy premium templates — and sell your own.",
+    items: [
+      "Premium paid templates for professional projects",
+      "A marketplace where you can list a template built with PersianLabs UI",
+      "Add your own contact button for payment right on your listing",
+    ],
+  },
+  {
+    title: "How paid templates work",
+    status: "later",
+    tagline: "Public or private — you stay in control after you buy.",
+    items: [
+      "Free templates ship from public repositories",
+      "Paid templates are private; after payment you're invited over Telegram",
+      "You get read-only access to the repo so you always receive updates",
+      "Open issues anytime to request updates or report problems",
+    ],
+  },
+]
+
+export default function TemplatesPage() {
+  return (
+    <RoadmapPage
+      eyebrow="Roadmap"
+      title="Templates"
+      description="Start-from templates built with PersianLabs UI — free and paid — plus a marketplace where you can sell your own. Free templates are public; paid ones are private and delivered over Telegram with lifetime read-only access."
+      phases={phases}
+    />
+  )
+}

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -34,16 +34,52 @@ const overview: Entry[] = [
       "What PersianLabs UI is, and why there's no separate installation flow - it's built entirely on top of shadcn/ui.",
   },
   {
+    title: "Installation",
+    href: "/docs/installation",
+    description:
+      "Adding PersianLabs/ui to a shadcn project - init once, then add any component by registry name or direct URL.",
+  },
+  {
     title: "Theming",
     href: "/docs/theming",
     description:
       "The CSS color variables the library ships with, light and dark, ready to copy.",
   },
   {
+    title: "RTL",
+    href: "/docs/rtl",
+    description:
+      "Setting up right-to-left rendering - the dir attribute, the Direction provider, LTR islands, and logical properties.",
+  },
+  {
+    title: "Fonts",
+    href: "/docs/fonts",
+    description:
+      "Choosing a Persian font stack - Vazirmatn and friends via next/font, with tabular digits and mono fallbacks.",
+  },
+  {
+    title: "Persian Conventions",
+    href: "/docs/persian-conventions",
+    description:
+      "A practical guide to Persian digits, grouped prices, the Toman currency, and Shamsi dates.",
+  },
+  {
+    title: "FAQ",
+    href: "/docs/faq",
+    description:
+      "Common questions and troubleshooting - hydration mismatches, RTL confusion, Base UI versions, and the registry and .md endpoints.",
+  },
+  {
     title: "AI",
     href: "/docs/ai",
     description:
       "Agent-facing entry points - the llms.txt catalog, a markdown twin for every doc page, and installs through the shadcn CLI.",
+  },
+  {
+    title: "CLI",
+    href: "/docs/cli",
+    description:
+      "Project starter generator - coming soon. Scaffold a Turborepo or plain Next.js app with the PersianLabs components you need and Vazir preinstalled.",
   },
   {
     title: "Charts",

--- a/apps/web/components/roadmap-page.tsx
+++ b/apps/web/components/roadmap-page.tsx
@@ -1,0 +1,87 @@
+import { cn } from "@workspace/ui/lib/utils"
+
+export interface RoadmapPhase {
+  title: string
+  status: "now" | "next" | "later"
+  tagline?: string
+  items: string[]
+}
+
+const STATUS_META = {
+  now: {
+    label: "In progress",
+    className:
+      "bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-400",
+  },
+  next: {
+    label: "Next up",
+    className:
+      "bg-blue-500/10 text-blue-600 dark:bg-blue-500/15 dark:text-blue-400",
+  },
+  later: {
+    label: "Later",
+    className: "bg-muted text-muted-foreground",
+  },
+} as const
+
+export function RoadmapPage({
+  eyebrow,
+  title,
+  description,
+  phases,
+}: {
+  eyebrow: string
+  title: string
+  description: string
+  phases: RoadmapPhase[]
+}) {
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-16 lg:px-8">
+      <p className="text-sm font-medium text-muted-foreground">{eyebrow}</p>
+      <h1 className="mt-2 text-3xl font-bold tracking-tight">{title}</h1>
+      <p className="mt-3 max-w-xl text-base leading-relaxed text-muted-foreground">
+        {description}
+      </p>
+
+      <div className="mt-12 flex flex-col gap-6">
+        {phases.map((phase) => {
+          const status = STATUS_META[phase.status]
+          return (
+            <section
+              key={phase.title}
+              className="rounded-2xl border border-border bg-card p-6"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-lg font-semibold">{phase.title}</h2>
+                <span
+                  className={cn(
+                    "shrink-0 rounded-full px-2.5 py-1 text-xs font-medium",
+                    status.className
+                  )}
+                >
+                  {status.label}
+                </span>
+              </div>
+              {phase.tagline && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {phase.tagline}
+                </p>
+              )}
+              <ul className="mt-4 flex flex-col gap-2.5">
+                {phase.items.map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-start gap-2.5 text-sm leading-relaxed text-foreground/90"
+                  >
+                    <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-foreground/40" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -11,8 +11,8 @@ import { GITHUB_REPO } from "@/lib/github"
 const navLinks = [
   { href: "/docs", label: "Docs" },
   { href: "/docs/components", label: "Components" },
-  { href: "#", label: "Blocks", disabled: true },
-  { href: "#", label: "Templates", disabled: true },
+  { href: "/blocks", label: "Blocks" },
+  { href: "/templates", label: "Templates" },
   { href: "https://icons.persian-labs.ir/", label: "Icons", external: true },
 ]
 
@@ -30,27 +30,17 @@ export function SiteHeader({
             <AppLogo className="size-5 text-foreground" />
           </Link>
           <nav className="hidden items-center gap-5 md:flex">
-            {navLinks.map((link) =>
-              link.disabled ? (
-                <span
-                  key={link.label}
-                  aria-disabled="true"
-                  className="cursor-not-allowed text-sm text-muted-foreground/50"
-                >
-                  {link.label}
-                </span>
-              ) : (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  target={link.external ? "_blank" : undefined}
-                  rel={link.external ? "noreferrer" : undefined}
-                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  {link.label}
-                </a>
-              )
-            )}
+            {navLinks.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                target={link.external ? "_blank" : undefined}
+                rel={link.external ? "noreferrer" : undefined}
+                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {link.label}
+              </a>
+            ))}
           </nav>
         </div>
 

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -1,0 +1,29 @@
+---
+title: "CLI"
+description: "A project starter generator - coming soon. Scaffold a Turborepo or plain Next.js app with the PersianLabs components you need and Vazir preinstalled."
+---
+
+> **Coming soon** — the CLI isn't available yet, but here's what it will do.
+
+The PersianLabs/ui CLI will scaffold a **ready-to-run starter project** so you don't wire anything up by hand. Instead of copy-pasting individual components one by one, one command generates a full app — Turborepo or plain Next.js — with the pieces you actually need.
+
+## What it will generate
+
+- A **Turborepo** workspace or a **plain Next.js** app, your choice
+- A selection of the **PersianLabs/ui components** you need, installed and wired
+- The **Vazir font** installed by default with the recommended Persian-first stack
+- Everything **pre-configured**: shadcn-ready registry, theming tokens, RTL (`dir="rtl"`), and the digit/date primitives — so your first render already looks like PersianLabs/ui.
+
+## Shape of the command (subject to change)
+
+```bash
+npx @persianlabs/cli@latest create my-app
+```
+
+You'll be asked which starter (Turborepo or Next.js), which components to include, and whether to use TypeScript. When it ships, this page will be updated with the full usage and options.
+
+## Why start with a starter
+
+PersianLabs/ui is copy-paste, but a few things are worth pre-configuring once — RTL, the Vazir font, the registry, and the theming tokens. A generator means every new project gets those right without re-reading [Installation](/docs/installation), [Theming](/docs/theming), [RTL](/docs/rtl), and [Fonts](/docs/fonts) each time.
+
+Follow the repo for the release announcement.

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -1,0 +1,36 @@
+---
+title: "FAQ"
+description: "Common questions and troubleshooting - hydration mismatches, RTL confusion, Base UI versions, and how the registry and .md endpoints work."
+---
+
+### Why did my page show a hydration mismatch or blank content?
+
+Reading the current time (`new Date()`, `Date.now()`) during render causes server/client differences. Defer time reads until after mount (e.g. `useEffect`), or use the hooks that already do — [useDate](/docs/utilities/use-date), [useTimeAgo](/docs/utilities/use-time-ago), [useCountdown](/docs/utilities/use-countdown).
+
+### Doesn't RTL "just work"?
+
+Yes — every component is RTL-first. But the document still needs `dir="rtl"` (see [RTL](/docs/rtl)). Mixed LTR/RTL content (code blocks, URLs) should stay LTR via the Direction provider or a `dir="ltr"` wrapper.
+
+### My Persian digits look wrong / aren't converting
+
+Make sure you normalize at the boundary: convert Arabic-Indic (٠-٩) _and_ Persian (۰-۹) to Latin for logic, then format back to Persian for display. [Normalize Persian Digits](/docs/utilities/normalize-persian-digits) and the inputs handle this for you.
+
+### Which Base UI version do I need?
+
+Components depend on `@base-ui/react` (Base UI) and use **no Radix**. Install via `npx shadcn@latest add @persianlabsui/<name>` and the CLI adds the correct dependency automatically. On manual installs, keep `@base-ui/react` recent.
+
+### I want the install command for a package manager other than npm
+
+Every install block on the site has pnpm/yarn/npm/bun tabs, and your choice is remembered. The markdown (`.md`) version shows the npm form.
+
+### Can I read these docs as plain markdown?
+
+Yes — append `.md` to any docs URL (e.g. `/docs/components/button.md`). The site-wide index is at [`/llms.txt`](/llms.txt).
+
+### A component seems to be missing a prop
+
+Check the API reference table on its page — it's generated from the actual source, so names and types there are authoritative.
+
+### Can I contribute?
+
+Yes. See the [contributing guide](https://github.com/persianlabs/ui/tree/main/docs/contributing) and the [agent guide](https://github.com/persianlabs/ui/tree/main/docs/agents).

--- a/apps/web/content/docs/fonts.mdx
+++ b/apps/web/content/docs/fonts.mdx
@@ -1,0 +1,114 @@
+---
+title: "Fonts"
+description: "Choose a Persian font stack - a Persian-first Vazir build with the ss01 feature setting, paired with Geist, plus local-font notes for Next.js."
+---
+
+Persian text renders best with a proper Arabic-script typeface. The resilient choice is a **Persian-first stack**: put a Persian font like _Vazir_ first, then a Latin font like Geist for Latin letters and digits.
+
+## 1. The stack we recommend
+
+Use a Persian font first, then Geist, so Persian glyphs come from the Persian family and Latin/digits fall through where they don't:
+
+```css
+:root {
+  --font-sans: "Vazir", "Vazirmatn", "Geist", system-ui, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+}
+```
+
+### Use a Vazir build without Latin and without Persian digits
+
+For the most flexible pairing, prefer a **Vazir build that ships no Latin glyphs and keeps Latin (0-9) digits** instead of forcing Persian digits:
+
+- Because it has no Latin, every Latin character automatically falls to Geist — so mixed Persian/English text and code look consistent.
+- Because digits stay Latin in the font, you aren't locked into ۰-۹ everywhere. Turn on Persian digits **only where you want them** with the digit utilities ([Normalize Persian Digits](/docs/utilities/normalize-persian-digits), `toPersianDigits` from [Persian Date](/docs/utilities/persian-date)), rather than having the base font decide for you.
+
+This keeps body copy, filenames, prices, and form values under your control instead of the font's.
+
+## 2. Persian fonts expose an `ss01` feature
+
+Many Persian/OpenType Persian fonts ship alternate glyphs behind the `ss01` font-feature-setting. Set it by default on your text so the preferred Persian forms render:
+
+```css
+body {
+  font-family: var(--font-sans);
+  font-feature-settings: "ss01";
+}
+```
+
+You can also scope it narrowly:
+
+```css
+/* Example: enable the alternate Persian forms site-wide, off in inputs */
+body {
+  font-feature-settings: "ss01";
+}
+```
+
+PersianLabs/ui components don't override this, so whatever you set on your base keeps applying to them.
+
+## 3. Adding a local font in Next.js
+
+If you self-host the font files (recommended for offline/perf), load them with `next/font/local`. Set `adjustFontFallback: false` so Next.js doesn't generate a Latin metric fallback that can fight the Arabic metrics:
+
+```tsx
+// app/layout.tsx
+import localFont from "next/font/local"
+
+const vazir = localFont({
+  src: "./fonts/Vazir.woff2",
+  weight: "100 900",
+  style: "normal",
+  variable: "--font-vazir",
+  adjustFontFallback: false,
+})
+
+const geist = localFont({
+  src: "./fonts/Geist.woff2",
+  variable: "--font-geist",
+  adjustFontFallback: false,
+})
+```
+
+```css
+:root {
+  --font-sans: "Vazir", "Geist", system-ui, sans-serif;
+}
+```
+
+The same `adjustFontFallback: false` applies to Google-font loading through `next/font/google` when you're layering an Arabic script next to a Latin one — it prevents metric fallback mismatches between the two families.
+
+## 4. If you're not using `next/font`
+
+Load the CSS manually and set the same tokens:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@100..900&display=swap"
+/>
+```
+
+```css
+body {
+  font-family: "Vazir", "Vazirmatn", "Geist", system-ui, sans-serif;
+  font-feature-settings: "ss01";
+}
+```
+
+## 5. Numerals and tabular alignment
+
+Values that must align numerically — prices, counts, tables — should use `tabular-nums`. The components already do:
+
+```tsx
+<span className="tabular-nums">۱۲۳٬۴۵۶</span>
+```
+
+## 6. Mixing Persian and code
+
+Commands, URLs, and code stay LTR and use your mono font (see [RTL → LTR islands](/docs/rtl#3-ltr-islands-in-an-rtl-page)). The install blocks across the docs set this up for you.
+
+## Next steps
+
+- [RTL](/docs/rtl) — wire up the text direction.
+- [Typography](/docs/components/typography) — the heading and paragraph styles the library expects.

--- a/apps/web/content/docs/installation.mdx
+++ b/apps/web/content/docs/installation.mdx
@@ -1,0 +1,58 @@
+---
+title: "Installation"
+description: "Add PersianLabs/ui to a shadcn project - init once, then add any component by registry name or direct URL."
+---
+
+PersianLabs/ui is distributed as a [shadcn-compatible registry](https://ui.shadcn.com/docs/registry), so there's no package to install and no version to chase. If your project already has shadcn configured, skip to step 2.
+
+## 1. Initialize shadcn
+
+Run the standard shadcn init once — nothing about this step is specific to this registry.
+
+<CopyCommand command="npx shadcn@latest init" />
+
+You can also use the equivalent for your package manager (`pnpm dlx`, `yarn dlx`, `bunx --bun`), or point shadcn directly at this registry:
+
+<CopyCommand command="npx shadcn@latest init -r https://ui.persian-labs.ir/r/registry.json" />
+
+## 2. Add a component
+
+Add any component by its registry namespace — the CLI copies the source straight into your project and wires dependencies automatically.
+
+<CopyCommand command="npx shadcn@latest add @persianlabsui/tabs" />
+
+The direct-URL form also works:
+
+<CopyCommand command="npx shadcn@latest add https://ui.persian-labs.ir/r/tabs.json" />
+
+To install everything the registry offers in one command, use the bundle endpoint:
+
+<CopyCommand command="npx shadcn@latest add https://ui.persian-labs.ir/r/registry.json" />
+
+## 3. Requirements
+
+| Requirement     | Notes                                                               |
+| --------------- | ------------------------------------------------------------------- |
+| React 19+       | Components are built against modern React.                          |
+| TypeScript 5+   | All source ships typed.                                             |
+| Tailwind CSS v4 | Uses the v4 CSS-first configuration.                                |
+| Base UI         | `@base-ui/react` — resolved automatically as a registry dependency. |
+| `lucide-react`  | Icons used across components.                                       |
+
+## 4. First render
+
+After adding a component, import it and drop it into your page:
+
+```tsx
+import { Button } from "@/components/ui/button"
+
+export function App() {
+  return <Button>ذخیره</Button>
+}
+```
+
+## Next steps
+
+- [Theming](/docs/theming) — copy the CSS color tokens into your `globals.css`.
+- [RTL](/docs/rtl) — confirm `dir="rtl"` and the logical-property conventions.
+- [Fonts](/docs/fonts) — pick a Persian font stack that pairs with the components.

--- a/apps/web/content/docs/meta.json
+++ b/apps/web/content/docs/meta.json
@@ -1,4 +1,16 @@
 {
   "title": "Docs",
-  "pages": ["index", "components", "theming", "ai", "utilities"]
+  "pages": [
+    "index",
+    "components",
+    "installation",
+    "theming",
+    "rtl",
+    "fonts",
+    "persian-conventions",
+    "faq",
+    "ai",
+    "cli",
+    "utilities"
+  ]
 }

--- a/apps/web/content/docs/persian-conventions.mdx
+++ b/apps/web/content/docs/persian-conventions.mdx
@@ -1,0 +1,59 @@
+---
+title: "Persian Numbers, Currency & Dates"
+description: "A practical guide to Persian digits, grouped prices, the Toman currency, and Shamsi dates - every component and utility that gets them right."
+---
+
+Persian interfaces have three recurring conventions that trip up otherwise-fine codebases: Persian digits, grouped currency, and Shamsi dates. This page points you at the components and utilities that handle each, and shows how they fit together.
+
+## 1. Digits — ۰-۹, not 0-9
+
+Users type and expect Persian digits. Normalize input and Persianify output with the same primitives the inputs use internally.
+
+| Need                                  | Tool                                                                                                                                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Convert Persian/Arabic-Indic to Latin | [Normalize Persian Digits](/docs/utilities/normalize-persian-digits)                                                                       |
+| Convert to Persian                    | `toPersianDigits` from [Persian Date](/docs/utilities/persian-date)                                                                        |
+| Read free-form user input             | [Mobile Number Input](/docs/components/mobile-number-input), [National ID Input](/docs/components/national-id-input) normalize as you type |
+
+## 2. Currency — Toman and grouped prices
+
+Toman is the everyday currency unit in Iran. The library ships a dedicated icon and a live-formatting price input.
+
+| Need                                   | Tool                                                                                                    |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| The Toman symbol                       | [Toman Icon](/docs/components/toman-icon)                                                               |
+| Live-grouped price input (`۱٬۲۳۴٬۵۶۷`) | [Price Input](/docs/components/price-input)                                                             |
+| Spell an amount for cheques/invoices   | [Number to Persian Words](/docs/utilities/number-to-persian-words) (`فقط دو میلیون و پانصد هزار تومان`) |
+
+A common amount flow, end to end:
+
+```tsx
+<PriceInput value={amount} onValueChange={setAmount} suffix={<TomanIcon />} />
+```
+
+## 3. Shamsi dates
+
+The Jalali calendar is the default for Persian products. Everything date-related is Shamsi/Jalali-aware and switchable.
+
+| Need                                | Tool                                                                                                 |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| A date picker (Shamsi or Gregorian) | [Date Picker](/docs/components/date-picker), [Date Wheel Picker](/docs/components/date-wheel-picker) |
+| Date math, formatting, conversion   | [Persian Date](/docs/utilities/persian-date)                                                         |
+| Validate dates in a schema          | [Persian Date (Zod)](/docs/utilities/persian-date-zod)                                               |
+| Know if a day is a holiday          | [Persian Holidays](/docs/utilities/persian-holidays)                                                 |
+| Relative time ("۲ روز پیش")         | [useTimeAgo](/docs/utilities/use-time-ago)                                                           |
+
+Example — format today and flag a holiday:
+
+```tsx
+import { formatDate, isHoliday } from "@/lib/persian-date"
+```
+
+## 4. Putting it together
+
+A typical checkout total, RTL, with Persian digits, Toman, and a Shamsi date stamp uses pieces from the sections above — the components share the same digit and date primitives, so the output stays consistent everywhere in your app.
+
+## Next steps
+
+- [Theming](/docs/theming) — tune the color tokens these components read.
+- [FAQ](/docs/faq) — common gotchas around digits, dates, and RTL.

--- a/apps/web/content/docs/rtl.mdx
+++ b/apps/web/content/docs/rtl.mdx
@@ -1,0 +1,63 @@
+---
+title: "RTL"
+description: "Set up right-to-left rendering for a Persian interface - the dir attribute, the Direction provider, LTR islands, and logical properties."
+---
+
+Every PersianLabs/ui component is RTL-first: it reads and mirrors correctly under `dir="rtl"` with zero special handling. This page covers how to turn that on and the few places RTL still needs a deliberate choice.
+
+## 1. Set the document direction
+
+The simplest way is to set `dir="rtl"` on the `<html>` element (and `lang="fa"` for the language):
+
+```html
+<html lang="fa" dir="rtl"></html>
+```
+
+All components inherit this direction automatically. Newer browsers also expose a setting that reports the user's preferred direction, which you can honor:
+
+```tsx
+// app/layout.tsx
+export const viewport: Viewport = {
+  // Allow users to override app direction via their browser setting
+}
+```
+
+## 2. The Direction provider
+
+Sometimes you need a different direction in one subtree — a dashboard widget, an embedded LTR block, or a nested locale. Use the [Direction](/docs/components/direction) component to override direction for its children, independent of the document:
+
+```tsx
+<Direction direction="ltr">{/* this subtree renders LTR */}</Direction>
+```
+
+Base UI primitives used under the hood read direction from this provider, so popovers, tooltips, and menus anchor to the correct side automatically.
+
+## 3. LTR islands in an RTL page
+
+Content that is _inherently_ left-to-right — code, commands, URLs — should stay LTR even on a Persian page. Wrap it or pin `dir="ltr"` on the element so punctuation and alignment stay correct:
+
+```tsx
+<div dir="ltr" className="font-mono">
+  npx shadcn@latest add @persianlabsui/button
+</div>
+```
+
+The install command blocks across the docs do exactly this.
+
+## 4. Logical properties
+
+Components use logical CSS (start/end, inline/block) so they flip automatically. When you write your own styles, prefer logical utilities:
+
+- `ms-*` / `me-*` instead of `ml-*` / `mr-*`
+- `ps-*` / `pe-*` instead of `pl-*` / `pr-*`
+- `text-start` / `text-end` instead of `text-left` / `text-right`
+- `border-s-*` / `border-e-*` instead of `border-l-*` / `border-r-*`
+
+## 5. Verify once
+
+Load a component page, flip the built-in direction toggle on its preview, and confirm the layout mirrors and directional icons point the right way. Every component ships with an RTL example you can inspect.
+
+## Next steps
+
+- [Fonts](/docs/fonts) — pair a Persian typeface with the layout.
+- [Persian Numbers, Currency & Dates](/docs/persian-conventions) — get digits, prices, and Shamsi dates right alongside RTL.

--- a/apps/web/lib/docs-nav.ts
+++ b/apps/web/lib/docs-nav.ts
@@ -16,8 +16,18 @@ export const docsNav: DocsNavGroup[] = [
     items: [
       { title: "Introduction", href: "/docs" },
       { title: "Components", href: "/docs/components" },
+      { title: "Installation", href: "/docs/installation" },
       { title: "Theming", href: "/docs/theming" },
+      { title: "RTL", href: "/docs/rtl" },
+      { title: "Fonts", href: "/docs/fonts" },
+      { title: "Persian Conventions", href: "/docs/persian-conventions" },
+      { title: "FAQ", href: "/docs/faq" },
       { title: "AI", href: "/docs/ai" },
+      {
+        title: "CLI",
+        href: "/docs/cli",
+        badge: "Coming soon",
+      },
       {
         title: "Skills",
         href: "/docs/skills",
@@ -217,18 +227,8 @@ export const docsNav: DocsNavGroup[] = [
   {
     title: "Resources",
     items: [
-      {
-        title: "Blocks",
-        href: "/docs/blocks",
-        badge: "Coming soon",
-        disabled: true,
-      },
-      {
-        title: "Templates",
-        href: "/docs/templates",
-        badge: "Coming soon",
-        disabled: true,
-      },
+      { title: "Blocks", href: "/blocks" },
+      { title: "Templates", href: "/templates" },
     ],
   },
 ]
@@ -244,7 +244,9 @@ export function getAdjacentDocsPages(href: string): {
   prev: DocsNavItem | null
   next: DocsNavItem | null
 } {
-  const flat = getFlatDocsNav()
+  // Only real doc pages participate in prev/next chaining — top-level
+  // roadmap pages (/blocks, /templates) live in the nav but aren't docs.
+  const flat = getFlatDocsNav().filter((item) => item.href.startsWith("/docs"))
   const index = flat.findIndex((item) => item.href === href)
 
   if (index === -1) {


### PR DESCRIPTION
﻿## What

Adds a fuller **Getting Started** section and enables **Blocks & Templates** as top-level roadmap pages.

## Getting-started docs

Six new MDX pages, each a real doc (gets its `.md` twin + llms.txt entry):

- **Installation** — shadcn init, add by namespace/direct URL, requirements, first render
- **RTL** — dir attr, Direction provider, LTR islands, logical properties
- **Fonts** — Persian-first Vazir stack, `ss01` feature setting, `adjustFontFallback: false` for local fonts, digit control
- **Persian Conventions** — digits, Toman/grouped prices, Shamsi dates (cross-links existing components/utilities)
- **FAQ** — hydration, RTL, Base UI versions, .md endpoints, contributing
- **CLI** — "Coming soon" page describing the planned starter generator (Turborepo or Next.js, Vazir + components preinstalled)

All registered in `content/docs/meta.json`, `lib/docs-nav.ts`, and `/llms.txt`.

## Blocks & Templates

Hosted at top-level **`/blocks`** and **`/templates`** (not under `/docs`) because they use a **different layout** from the docs — a shared SiteHeader with no docs sidebar, via a new `(roadmap)` route group and a reusable `RoadmapPage` component (In progress / Next up / Later phases).

- Header nav: **Blocks** and **Templates** links enabled
- Docs sidebar Resources group: non-disabled entries pointing at the new URLs
- `getAdjacentDocsPages` now only chains among `/docs` pages so the last docs page no longer links forward to `/blocks`

## Commits
- `b3e8881` docs(getting-started): installation, RTL, fonts, conventions, FAQ, CLI
- `241809a` feat(roadmap): Blocks/Templates pages, header links, nav wiring

## Verified
Root typecheck ✓ · ESLint ✓ · Prettier ✓ · MDX guard ✓ · live: all 7 new routes 200, header shows `/blocks` + `/templates`, llms.txt lists new slugs, `.md` endpoints clean.
