### PR TITLE
fix(ci): poll the local registry server in install-smoke instead of a fixed 3s sleep

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -58,9 +58,23 @@ jobs:
           bun -e "const j = JSON.parse(require('fs').readFileSync('registry.json', 'utf8')); require('fs').writeFileSync('/tmp/names.txt', j.items.map((i) => i.name).join('\n'))"
       - name: Serve registry locally
         run: |
-          npx -y serve apps/web/public -l 4173 &
-          sleep 3
-          curl -sf http://localhost:4173/r/button.json > /dev/null
+          npx -y serve apps/web/public -l 4173 > "$RUNNER_TEMP/serve.log" 2>&1 &
+          # npx cold-starts by downloading `serve` first, so readiness is racy
+          # with a fixed sleep — poll until the registry actually answers.
+          ok=0
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:4173/r/button.json > /dev/null; then
+              echo "registry server ready after ${i}s"
+              ok=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ok" != "true" ]; then
+            cat "$RUNNER_TEMP/serve.log"
+            echo "registry server did not come up within 60s"
+            exit 1
+          fi
       - name: Scaffold consumer project
         run: |
           cd "$RUNNER_TEMP"


### PR DESCRIPTION
The `install-smoke` workflow's `consumer-install` job has failed every scheduled run for days at the same step, with exit code 7 that is easy to misread.

## Root cause

Exit code **7 is curl's "ECONNREFUSED"**: the step was

```
npx -y serve apps/web/public -l 4173 &
sleep 3
curl -sf http://localhost:4173/r/button.json > /dev/null
```

`npx -y serve` must first download `serve` from the npm registry (the runner cache is cold every run), so the local server is not up after a fixed 3s sleep — the single curl attempt always fails before `serve` starts listening. The run log confirms it: the job cleanup afterwards found the orphaned `npm exec serve` process still alive; the server came up right after the step had already failed.

## Fix

Replace the fixed sleep with a readiness poll: launch `serve`, then attempt the same curl up to 60 times (1s apart), printing when the server is ready and dumping the serve log if it isn't up within 60s. No functional changes to what the job verifies.
