### PR TITLE
feat(utility): switch the cn() helper to the cn engine

### DIFF
--- a/apps/web/public/r/registry.json
+++ b/apps/web/public/r/registry.json
@@ -955,9 +955,9 @@
       "name": "utils",
       "type": "registry:lib",
       "title": "Utils",
-      "description": "The cn() class-merging helper built on clsx and tailwind-merge.",
+      "description": "The cn() class-merging helper, powered by the cn package (a drop-in clsx + tailwind-merge engine).",
       "registryDependencies": [],
-      "dependencies": ["clsx", "tailwind-merge"],
+      "dependencies": ["cn"],
       "files": [
         {
           "path": "registry/base/lib/utils.ts",

--- a/apps/web/public/r/utils.json
+++ b/apps/web/public/r/utils.json
@@ -2,16 +2,15 @@
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "utils",
   "title": "Utils",
-  "description": "The cn() class-merging helper built on clsx and tailwind-merge.",
+  "description": "The cn() class-merging helper, powered by the cn package (a drop-in clsx + tailwind-merge engine).",
   "dependencies": [
-    "clsx",
-    "tailwind-merge"
+    "cn"
   ],
   "registryDependencies": [],
   "files": [
     {
       "path": "registry/base/lib/utils.ts",
-      "content": "import { clsx, type ClassValue } from \"clsx\"\nimport { twMerge } from \"tailwind-merge\"\n\nexport function cn(...inputs: ClassValue[]) {\n  return twMerge(clsx(inputs))\n}\n",
+      "content": "export { cn } from \"cn\"\n",
       "type": "registry:lib"
     }
   ],

--- a/apps/web/registry.json
+++ b/apps/web/registry.json
@@ -955,9 +955,9 @@
       "name": "utils",
       "type": "registry:lib",
       "title": "Utils",
-      "description": "The cn() class-merging helper built on clsx and tailwind-merge.",
+      "description": "The cn() class-merging helper, powered by the cn package (a drop-in clsx + tailwind-merge engine).",
       "registryDependencies": [],
-      "dependencies": ["clsx", "tailwind-merge"],
+      "dependencies": ["cn"],
       "files": [
         {
           "path": "registry/base/lib/utils.ts",

--- a/apps/web/registry/base/lib/utils.ts
+++ b/apps/web/registry/base/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from "cn"

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
         "@persianlabs/icons": "^1.0.2",
         "@shadcn/react": "^0.3.0",
         "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
+        "cn": "^0.2.5",
         "date-fns": "^4.4.0",
         "date-fns-jalali": "^4.4.0-0",
         "embla-carousel-react": "^8.6.0",
@@ -122,7 +122,6 @@
         "react-use-measure": "^2.1.7",
         "react-virtuoso": "^4.18.12",
         "shadcn": "^4.19.0",
-        "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.4.3",
       },
@@ -846,6 +845,8 @@
     "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cn": ["cn@0.2.5", "", { "bin": { "cn": "bin/cn.mjs" } }, "sha512-OCjZtMeQfXbI4Es1+EIjkd77gvWzaE689gD8KhfexlqjClC06qR1MQBR+Z35ZMSPNEBWyHiItW1Soy0UvwNv9w=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
     "@persianlabs/icons": "^1.0.2",
     "@shadcn/react": "^0.3.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.5",
     "date-fns": "^4.4.0",
     "date-fns-jalali": "^4.4.0-0",
     "embla-carousel-react": "^8.6.0",
@@ -39,7 +39,6 @@
     "react-use-measure": "^2.1.7",
     "react-virtuoso": "^4.18.12",
     "shadcn": "^4.19.0",
-    "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.4.3"
   },

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from "cn"


### PR DESCRIPTION
Replaces the `clsx` + `tailwind-merge` implementation of `lib/utils.ts` with the new [`cn` engine](https://github.com/shadcn-ui/cn) (drop-in, full parity, ~30× faster, 26 KB with zero dependencies).

## Changes

- `lib/utils.ts` (source **and** registry twin) is now the one-liner `export { cn } from "cn"`
- `packages/ui` dependency swap: `cn` in, `clsx`/`tailwind-merge` removed
- `registry.json` `utils` item: dependency `cn`, description updated; `public/r/*.json` rebuilt

Consumers installing any component still get `cn` transitively via `registryDependencies: ["utils"]`, and user code strictly imports `cn` from `@/lib/utils`, so this is zero-touch from the outside.

## Validation

- `bun run typecheck` ✓ (whole workspace compiles through the new engine)
- `bun run lint` ✓, `bun run test` ✓ (262 tests, 17 files)
- mirror parity 109/109 ✓
- `bun run build` ✓ (turbo)
- `bun run registry:build` ✓ — `public/r/utils.json` now ships the one-liner with `"dependencies": ["cn"]`
- Behavior smoke: conflict resolution/conditionals/dedupe identical to `twMerge(clsx(...))` on the critical cases (`px-2 py-1` + `py-2`, conditional drops, logical `-ms-4`/`ms-2` overrides)
