### PR TITLE
chore(templates): TypeScript 7 side-by-side, @types/node 26

### DIFF
--- a/templates/next-app/package.json
+++ b/templates/next-app/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
@@ -34,7 +34,8 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/next-monorepo/apps/web/package.json
+++ b/templates/next-monorepo/apps/web/package.json
@@ -25,16 +25,17 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@workspace/eslint-config": "workspace:^",
     "@workspace/typescript-config": "workspace:*",
     "eslint": "^9",
     "tailwindcss": "^4",
-    "typescript": "^5",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "eslint-config-next": "16.3.4",
     "prettier": "^3.8.3",
-    "prettier-plugin-tailwindcss": "^0.8.0"
+    "prettier-plugin-tailwindcss": "^0.8.0",
+    "@typescript/native": "npm:typescript@^7.0.2"
   }
 }

--- a/templates/next-monorepo/packages/ui/package.json
+++ b/templates/next-monorepo/packages/ui/package.json
@@ -23,14 +23,15 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@turbo/gen": "^2.9.15",
-    "@types/node": "^20",
+    "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@workspace/eslint-config": "workspace:*",
     "@workspace/typescript-config": "workspace:*",
     "eslint": "^9",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "exports": {
     "./globals.css": "./src/styles/globals.css",

--- a/templates/vite-app/package.json
+++ b/templates/vite-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc6 -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10",
-    "@types/node": "^24",
+    "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6",
@@ -38,9 +38,10 @@
     "globals": "^17",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
-    "typescript": "~6",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8",
-    "vite": "^8"
+    "vite": "^8",
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/templates/vite-monorepo/apps/web/package.json
+++ b/templates/vite-monorepo/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc6 -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10",
-    "@types/node": "^24",
+    "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6",
@@ -37,9 +37,10 @@
     "globals": "^17",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
-    "typescript": "~6",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8",
-    "vite": "^8"
+    "vite": "^8",
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

Follows the [Next.js 16.3 blog](https://nextjs.org/blog/next-16-3#faster-type-checking-with-typescript-7) guidance for adopting TypeScript 7, using the [official side-by-side setup](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6) so lint keeps working:

- `typescript` → `npm:@typescript/typescript6@^6.0.2` — the compiler API that `typescript-eslint` still requires (it hard-blocks TS 7.0, support tracked in typescript-eslint#10940)
- `@typescript/native` → `npm:typescript@^7.0.2` — the 10x-faster native compiler
- Vite bases: build script runs `tsc6 -b` (the TS6 alias ships the `tsc6` binary)
- `@types/node` → `^26` in all four bases

**Deliberately held back (upstream blockers, tested):**
- **ESLint 10 in Next bases**: `eslint-config-next`'s chain pulls `eslint-plugin-react`, which still peers `eslint <= ^9.7` — crashes at lint time. Vite bases are already on 10.
- Everything else (next 16.3.4, react 19.2.8, lucide-react 1.42, tailwind 4.3.3, prettier 3.9.6) is already at latest via #90.

## Validation
Fresh scaffolds of next + vite with the updated templates: lint ✅ build ✅, resolving TS native 7.0.2 / API 6.0.2 / @types/node 26.5.0.