### PR TITLE
fix(cli): keep the bin in published metadata

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Verify CLI
         working-directory: packages/cli
         run: bun run typecheck && bun run test
+      # Build dist/ before npm reads package.json — otherwise npm sees no
+      # dist/index.js in the checkout, warns "No bin file found" and strips
+      # the bin from the published metadata.
+      - name: Build CLI
+        working-directory: packages/cli
+        run: bun run build
       # OIDC trusted publishing needs npm >= 11.5.1; Node 22 ships npm 10.
       - uses: actions/setup-node@v4
         with:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,9 @@
   "description": "Scaffold and theme RTL-first, Persian-typography shadcn projects - init from a /create preset, add components from the Persian Labs registry.",
   "license": "MIT",
   "type": "module",
-  "bin": "./dist/index.js",
+  "bin": {
+    "persianlabsui": "dist/index.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes the bin being stripped from the published package (npm 11 rejects './'-prefixed bin paths) and builds dist/ before npm validates it in publish-cli.yml.

Verified locally: \
pm pack\ of persianlabsui@0.1.1 now ships \in.persianlabsui = dist/index.js\ with the #!/usr/bin/env node shebang, no 'No bin file found' / 'auto-corrected' npm warnings.

Note: the 0.1.1 E404 is a separate npm-account issue — the OIDC trusted publisher must be granted publish permission on the existing persianlabsui package (owner: taymakz); that cannot be fixed in-repo.