### PR TITLE
fix(cli): pnpm-first install via npx, single deps message, Vite 8 config + v0.1.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persianlabsui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Scaffold and theme RTL-first, Persian-typography shadcn projects - init from a /create preset, add components from the Persian Labs registry.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -53,9 +53,9 @@ export async function runInit(options: {
   const baseCwd = path.resolve(options.cwd)
   const config = resolveConfig(options.preset)
   const silent = options.silent ?? false
-  // The manager the user created the project with (pnpm→pnpm, npm→npm,
-  // bun→bun) — scaffolding, shadcn and the final install all
-  // follow it so the project never gets pinned to another manager.
+  // The manager the user created the project with — bunx→bun, pnpm dlx→
+  // pnpm, npx→pnpm (falling back to npm). Scaffolding, shadcn and the
+  // final install all follow it so the project is never pinned elsewhere.
   // --package-manager overrides the auto-detection from npm_config_user_agent.
   const pm: PackageManager = options.packageManager
     ? resolvePackageManager(options.packageManager)
@@ -135,11 +135,6 @@ export async function runInit(options: {
   await writeFile(tempFile, JSON.stringify(registryBase, null, 2))
 
   try {
-    if (!silent) {
-      p.log.step("Installing dependencies.")
-    } else {
-      logger.log("  Installing via shadcn CLI...")
-    }
     await runShadcnAdd([tempFile], {
       cwd: uiDir,
       overwrite: true,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ const program = new Command()
   .description(
     "Add RTL-first, Persian-typography components built on Base UI to your project."
   )
-  .version("0.1.0")
+  .version("0.1.2")
 
 program
   .command("init")

--- a/packages/cli/src/utils/package-manager.ts
+++ b/packages/cli/src/utils/package-manager.ts
@@ -60,8 +60,10 @@ export function getPackageManagerVersion(pm: PackageManager): string | null {
   return runManagerVersion(pm)
 }
 
-// Strict mapping: pnpm→pnpm, npm→npm, bun→bun. The fallback chains only
-// kick in when the preferred binary is missing.
+// pnpm→pnpm, bun→bun. Invoked via npx/npm ("npm" agent) we still prefer
+// pnpm when it is on the machine and only fall back to npm — npx is just
+// the runner, pnpm the faster/better install for the project. The other
+// chains fall back when the preferred binary is missing.
 export function resolvePackageManager(
   preferred?: PackageManager | null
 ): PackageManager {
@@ -72,9 +74,8 @@ export function resolvePackageManager(
     case "bun":
       return isPackageManagerAvailable("bun") ? "bun" : "npm"
     case "npm":
-      if (isPackageManagerAvailable("npm")) return "npm"
       if (isPackageManagerAvailable("pnpm")) return "pnpm"
-      return "npm"
+      return isPackageManagerAvailable("npm") ? "npm" : "pnpm"
     default:
       if (isPackageManagerAvailable("pnpm")) return "pnpm"
       if (isPackageManagerAvailable("npm")) return "npm"

--- a/templates/vite-app/vite.config.ts
+++ b/templates/vite-app/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/templates/vite-monorepo/apps/web/vite.config.ts
+++ b/templates/vite-monorepo/apps/web/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })


### PR DESCRIPTION
## Fixes
- **pnpm-first via npx**: `resolvePackageManager` treated an npm/npx user-agent as "use npm". Now npx-seeded projects prefer `pnpm` when it exists and only fall back to npm (bunx→bun, pnpm dlx→pnpm unchanged) — a machine with pnpm installed no longer installs deps with npm.
- **Single deps message**: `init` printed "◇ Installing dependencies." and later "◇ Installing dependencies with npm." (duplicate). Kept only the final message naming the manager.
- **Vite 8 config warning**: both vite templates used `__dirname`, which Vite 8's native `configLoader` warns about. Switched to `import.meta.dirname`.

## Version
- Bumped `packages/cli` to **0.1.2** and fixed the stale hardcoded `commander .version()` in `src/index.ts` (was still 0.1.0).

Verified locally: CLI `tsc --noEmit` + 15 vitest pass, isolated tsc probe for `import.meta.dirname` under the template tsconfig settings, Prettier clean.

After merge: dispatch `publish-cli.yml` to publish 0.1.2.