### PR TITLE
docs(message): add a mixed-direction content example

### DIFF
--- a/apps/web/components/examples/__map__.ts
+++ b/apps/web/components/examples/__map__.ts
@@ -976,6 +976,10 @@ export const exampleLoaders: Record<
     import("@/components/examples/message-demo").then(
       (m) => m.MessageDemoExample
     ),
+  "message-mixed-direction": () =>
+    import("@/components/examples/message-mixed-direction").then(
+      (m) => m.MessageMixedDirectionExample
+    ),
   "message-rtl": () =>
     import("@/components/examples/message-rtl").then(
       (m) => m.MessageRtlExample
@@ -2090,6 +2094,7 @@ export type ExampleMap = {
   "menubar-demo": React.ComponentType
   "menubar-rtl": React.ComponentType
   "message-demo": React.ComponentType
+  "message-mixed-direction": React.ComponentType
   "message-rtl": React.ComponentType
   "message-scroller-demo": React.ComponentType
   "message-scroller-rtl": React.ComponentType

--- a/apps/web/components/examples/message-mixed-direction.tsx
+++ b/apps/web/components/examples/message-mixed-direction.tsx
@@ -1,0 +1,76 @@
+import { Bubble, BubbleContent } from "@workspace/ui/components/bubble"
+import {
+  Message,
+  MessageContent,
+  MessageGroup,
+} from "@workspace/ui/components/message"
+
+export function MessageMixedDirectionExample() {
+  return (
+    <MessageGroup className="w-full max-w-lg">
+      <Message align="start">
+        <MessageContent>
+          <Bubble variant="muted">
+            <BubbleContent className="flex flex-col gap-2">
+              <p lang="fa" dir="rtl" className="text-start">
+                <bdi dir="ltr" translate="no">
+                  React
+                </bdi>{" "}
+                یک کتابخانه جاوااسکریپت بسیار محبوب است.
+              </p>
+              <p lang="en" dir="ltr" className="text-start">
+                The label is «
+                <bdi lang="fa" dir="rtl">
+                  ذخیره
+                </bdi>
+                » in Persian.
+              </p>
+            </BubbleContent>
+          </Bubble>
+        </MessageContent>
+      </Message>
+      <Message align="end">
+        <MessageContent>
+          <Bubble align="end">
+            <BubbleContent>
+              {/* Physical left alignment is intentional, independent of dir. */}
+              <p lang="fa" dir="rtl" className="text-left">
+                این جمله فارسی عمداً از سمت چپ تراز شده است.
+              </p>
+            </BubbleContent>
+          </Bubble>
+        </MessageContent>
+      </Message>
+      <Message align="start">
+        <MessageContent>
+          <Bubble variant="muted">
+            <BubbleContent>
+              <p lang="fa" dir="rtl" className="text-start">
+                دستور{" "}
+                <bdi dir="ltr">
+                  <code translate="no">npm run build</code>
+                </bdi>{" "}
+                را اجرا کنید و{" "}
+                <bdi dir="ltr" translate="no">
+                  https://example.com/docs?q=rtl
+                </bdi>{" "}
+                را ببینید.
+              </p>
+            </BubbleContent>
+          </Bubble>
+        </MessageContent>
+      </Message>
+      <Message align="end">
+        <MessageContent>
+          <Bubble align="end">
+            <BubbleContent>
+              <p lang="en" dir="ltr" className="text-start">
+                Everything is ready. Version 2.1 works.
+              </p>
+            </BubbleContent>
+          </Bubble>
+        </MessageContent>
+      </Message>
+    </MessageGroup>
+  )
+}

--- a/apps/web/content/docs/components/message.mdx
+++ b/apps/web/content/docs/components/message.mdx
@@ -66,6 +66,37 @@ export function Example() {
 
 <ComponentPreview name="message-rtl" direction="rtl" />
 
+### Mixed-language content
+
+Bubble placement, paragraph direction, and text alignment are independent:
+
+- Keep `Message` / `Bubble` `align` for start/end placement in the surrounding UI.
+- Set `dir` on each prose paragraph, not the whole message row. A single bubble
+  can contain both Persian and English paragraphs without moving its avatar or tail.
+- Use `text-start` for direction-aware alignment. Use `text-left` only when the
+  product deliberately wants the physical left edge, including for Persian text.
+  This is an intentional exception to the usual logical-property rule.
+- Wrap a known opposite-direction inline fragment with native `<bdi dir="ltr">`
+  or `<bdi dir="rtl">`; do not reverse strings or insert hidden controls into
+  the stored message. Keep code and URL text in its original order.
+
+<ComponentPreview name="message-mixed-direction" />
+
+The directions above are explicit author choices for these known examples, not
+language detection. Native `dir="auto"` uses first-strong direction, not the
+majority language. In an unmarked plain-text paragraph, a leading `React`
+identifier can therefore select LTR for Persian prose. Text inside `<bdi>` is
+excluded from that first-strong scan. For unknown user/AI text, offer an
+Auto/LTR/RTL override or apply
+your chosen content-direction policy at the paragraph boundary. Preserve an
+explicit caller choice. The Direction provider still controls component layout.
+
+Try the preview in both UI directions and at a narrow width. The English control
+paragraph must stay LTR, the intentionally left-aligned Persian paragraph must
+stay RTL, and selecting/copying a paragraph must retain its logical source text.
+Screen-reader pronunciation and editor caret/IME behavior need separate testing;
+this example is read-only message presentation, not an editor integration.
+
 ## API Reference
 
 <ApiReference title="Message" rows={messageApi} />

--- a/apps/web/content/docs/components/message.mdx
+++ b/apps/web/content/docs/components/message.mdx
@@ -89,7 +89,8 @@ identifier can therefore select LTR for Persian prose. Text inside `<bdi>` is
 excluded from that first-strong scan. For unknown user/AI text, offer an
 Auto/LTR/RTL override or apply
 your chosen content-direction policy at the paragraph boundary. Preserve an
-explicit caller choice. The Direction provider still controls component layout.
+explicit caller choice. Keep the surrounding UI's layout direction on the
+message row or an ancestor, separate from each paragraph's `dir`.
 
 Try the preview in both UI directions and at a narrow width. The English control
 paragraph must stay LTR, the intentionally left-aligned Persian paragraph must

--- a/apps/web/content/docs/rtl.mdx
+++ b/apps/web/content/docs/rtl.mdx
@@ -53,7 +53,19 @@ Components use logical CSS (start/end, inline/block) so they flip automatically.
 - `text-start` / `text-end` instead of `text-left` / `text-right`
 - `border-s-*` / `border-e-*` instead of `border-l-*` / `border-r-*`
 
-## 5. Verify once
+## 5. Mixed-language messages
+
+UI layout direction does not determine the language of every message. Set `dir`
+on individual prose paragraphs and isolate opposite-direction inline fragments
+with `<bdi>`. Keep message placement and text alignment separate: a Persian
+paragraph can use `dir="rtl"` and deliberately be physically left-aligned.
+
+See the [mixed-language Message example](/docs/components/message#mixed-language-content)
+for Persian prose beginning with `React`, English containing a Persian label,
+code/URL fragments, and a pure-English control. It uses native markup and the
+existing components, with no extra package or change to global defaults.
+
+## 6. Verify once
 
 Load a component page, flip the built-in direction toggle on its preview, and confirm the layout mirrors and directional icons point the right way. Every component ships with an RTL example you can inspect.
 


### PR DESCRIPTION
Following the invitation in #84, this adds a small mixed-language example to the existing Message docs.

The example keeps three decisions separate: message/bubble placement, paragraph reading direction, and text alignment. It includes Persian beginning with `React`, English containing a Persian label, isolated code/URL fragments, deliberately left-aligned Persian, and an English-only control. Both preview directions remain selectable.

There is no new dependency, global CSS change, direction detector, or change to Message/Bubble defaults. The existing components are composed with native `dir`, `lang`, and `bdi` markup. The RTL guide links to the example. The example map was regenerated and formatted.

### Checks

- Bun 1.4.0 frozen install, production build, typecheck, format, and MDX component-reference check passed.
- Lint passed with 0 errors; 8 warnings are in untouched existing files.
- Local Chromium, Firefox, and WebKit: 375px and 1100px viewports, both directions using the real preview control. Exact DOM text and selection text, paragraph direction, left alignment, inline isolation, and overflow checks passed. Screenshots were also inspected.
- The generated Markdown endpoint includes the new section and copyable example source.

To inspect locally: open `/docs/components/message`, scroll to **Mixed-language content**, toggle direction, and open the fullscreen preview. Its direct route is `/preview/c/message/mixed-language-content`.

This is read-only presentation. I have not claimed system-clipboard, screen-reader, or editor/IME validation. Explicit directions in the fixtures are author choices, not automatic language detection; the docs explain the first-strong limitation and the need to preserve caller overrides.

Disclosure: I maintain [BidiLens](https://github.com/CodeinScrubs/BidiLens), which motivated the original proposal. This contribution intentionally uses native markup and does not ask PersianLabs to adopt that dependency.

Closes #84.
